### PR TITLE
Implements Check Command

### DIFF
--- a/bin/laradumps
+++ b/bin/laradumps
@@ -2,9 +2,9 @@
 <?php
 
 if (file_exists(__DIR__ . '/../../../autoload.php')) {
-    include __DIR__ . '/../../../autoload.php';
-} else if (file_exists(__DIR__ . '/../autoload.php')) {
-    include __DIR__ . '/../autoload.php';
+    require_once __DIR__ . '/../../../autoload.php';
+} else if (file_exists(__DIR__ . '/vendor/autoload.php')) {
+    require_once __DIR__ . '/vendor/autoload.php';
 }
 
 use LaraDumps\LaraDumpsCore\Commands\ClearV1ConfigCommand;

--- a/bin/laradumps
+++ b/bin/laradumps
@@ -7,6 +7,7 @@ if (file_exists(__DIR__ . '/../../../autoload.php')) {
     require_once __DIR__ . '/vendor/autoload.php';
 }
 
+use LaraDumps\LaraDumpsCore\Commands\CheckCommand;
 use LaraDumps\LaraDumpsCore\Commands\ClearV1ConfigCommand;
 use LaraDumps\LaraDumpsCore\Commands\ConfigureDesktopAppCommand;
 use Symfony\Component\Console\Application;
@@ -14,4 +15,5 @@ use Symfony\Component\Console\Application;
 $application = new Application('LaraDumps Core', 'v1.0.0');
 $application->add(new ClearV1ConfigCommand());
 $application->add(new ConfigureDesktopAppCommand());
+$application->add(new CheckCommand());
 $application->run();

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,9 @@
         "symfony/console": "^5.0|^6.0",
         "ext-curl": "*",
         "nesbot/carbon": "^2.66",
-        "symfony/process": "^6.2",
-        "symfony/finder": "^6.2"
+        "symfony/process": "^5.0|^6.0",
+        "symfony/finder": "^5.0|^6.0",
+        "nunomaduro/termwind": "^1.15"
     },
     "require-dev": {
         "laravel/pint": "^1.10",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,9 @@
         "symfony/var-dumper": "^5.0|^6.0",
         "symfony/console": "^5.0|^6.0",
         "ext-curl": "*",
-        "nesbot/carbon": "^2.66"
+        "nesbot/carbon": "^2.66",
+        "symfony/process": "^6.2",
+        "symfony/finder": "^6.2"
     },
     "require-dev": {
         "laravel/pint": "^1.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7b228b152519853ed526fefba4728b00",
+    "content-hash": "dd9d9f73b99428e787b8f9f5382a8609",
     "packages": [
         {
             "name": "brick/math",
@@ -224,6 +224,92 @@
                 }
             ],
             "time": "2023-01-29T18:53:47+00:00"
+        },
+        {
+            "name": "nunomaduro/termwind",
+            "version": "v1.15.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nunomaduro/termwind.git",
+                "reference": "8ab0b32c8caa4a2e09700ea32925441385e4a5dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/8ab0b32c8caa4a2e09700ea32925441385e4a5dc",
+                "reference": "8ab0b32c8caa4a2e09700ea32925441385e4a5dc",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^8.0",
+                "symfony/console": "^5.3.0|^6.0.0"
+            },
+            "require-dev": {
+                "ergebnis/phpstan-rules": "^1.0.",
+                "illuminate/console": "^8.0|^9.0",
+                "illuminate/support": "^8.0|^9.0",
+                "laravel/pint": "^1.0.0",
+                "pestphp/pest": "^1.21.0",
+                "pestphp/pest-plugin-mock": "^1.0",
+                "phpstan/phpstan": "^1.4.6",
+                "phpstan/phpstan-strict-rules": "^1.1.0",
+                "symfony/var-dumper": "^5.2.7|^6.0.0",
+                "thecodingmachine/phpstan-strict-rules": "^1.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Termwind\\Laravel\\TermwindServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Functions.php"
+                ],
+                "psr-4": {
+                    "Termwind\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Its like Tailwind CSS, but for the console.",
+            "keywords": [
+                "cli",
+                "console",
+                "css",
+                "package",
+                "php",
+                "style"
+            ],
+            "support": {
+                "issues": "https://github.com/nunomaduro/termwind/issues",
+                "source": "https://github.com/nunomaduro/termwind/tree/v1.15.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/xiCO2k",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-08T01:06:31+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -2363,92 +2449,6 @@
                 }
             ],
             "time": "2023-04-22T22:12:40+00:00"
-        },
-        {
-            "name": "nunomaduro/termwind",
-            "version": "v1.15.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nunomaduro/termwind.git",
-                "reference": "8ab0b32c8caa4a2e09700ea32925441385e4a5dc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/8ab0b32c8caa4a2e09700ea32925441385e4a5dc",
-                "reference": "8ab0b32c8caa4a2e09700ea32925441385e4a5dc",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "php": "^8.0",
-                "symfony/console": "^5.3.0|^6.0.0"
-            },
-            "require-dev": {
-                "ergebnis/phpstan-rules": "^1.0.",
-                "illuminate/console": "^8.0|^9.0",
-                "illuminate/support": "^8.0|^9.0",
-                "laravel/pint": "^1.0.0",
-                "pestphp/pest": "^1.21.0",
-                "pestphp/pest-plugin-mock": "^1.0",
-                "phpstan/phpstan": "^1.4.6",
-                "phpstan/phpstan-strict-rules": "^1.1.0",
-                "symfony/var-dumper": "^5.2.7|^6.0.0",
-                "thecodingmachine/phpstan-strict-rules": "^1.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "Termwind\\Laravel\\TermwindServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/Functions.php"
-                ],
-                "psr-4": {
-                    "Termwind\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nuno Maduro",
-                    "email": "enunomaduro@gmail.com"
-                }
-            ],
-            "description": "Its like Tailwind CSS, but for the console.",
-            "keywords": [
-                "cli",
-                "console",
-                "css",
-                "package",
-                "php",
-                "style"
-            ],
-            "support": {
-                "issues": "https://github.com/nunomaduro/termwind/issues",
-                "source": "https://github.com/nunomaduro/termwind/tree/v1.15.1"
-            },
-            "funding": [
-                {
-                    "url": "https://www.paypal.com/paypalme/enunomaduro",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/nunomaduro",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/xiCO2k",
-                    "type": "github"
-                }
-            ],
-            "time": "2023-02-08T01:06:31+00:00"
         },
         {
             "name": "pestphp/pest",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "21802829251aa21d0e04f7e1ffd3847e",
+    "content-hash": "7b228b152519853ed526fefba4728b00",
     "packages": [
         {
             "name": "brick/math",
@@ -698,6 +698,70 @@
             "time": "2023-03-01T10:25:55+00:00"
         },
         {
+            "name": "symfony/finder",
+            "version": "v6.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "20808dc6631aecafbe67c186af5dcb370be3a0eb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/20808dc6631aecafbe67c186af5dcb370be3a0eb",
+                "reference": "20808dc6631aecafbe67c186af5dcb370be3a0eb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "symfony/filesystem": "^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Finds files and directories via an intuitive fluent interface",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v6.2.7"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-02-16T09:57:23+00:00"
+        },
+        {
             "name": "symfony/polyfill-ctype",
             "version": "v1.27.0",
             "source": {
@@ -1109,6 +1173,67 @@
                 }
             ],
             "time": "2022-11-03T14:55:06+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v6.2.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "97ae9721bead9d1a39b5650e2f4b7834b93b539c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/97ae9721bead9d1a39b5650e2f4b7834b93b539c",
+                "reference": "97ae9721bead9d1a39b5650e2f4b7834b93b539c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v6.2.11"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-05-19T07:42:48+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -4324,131 +4449,6 @@
                 }
             ],
             "time": "2023-02-07T11:34:05+00:00"
-        },
-        {
-            "name": "symfony/finder",
-            "version": "v6.2.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/finder.git",
-                "reference": "20808dc6631aecafbe67c186af5dcb370be3a0eb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/20808dc6631aecafbe67c186af5dcb370be3a0eb",
-                "reference": "20808dc6631aecafbe67c186af5dcb370be3a0eb",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "require-dev": {
-                "symfony/filesystem": "^6.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Finder\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Finds files and directories via an intuitive fluent interface",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/finder/tree/v6.2.7"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-02-16T09:57:23+00:00"
-        },
-        {
-            "name": "symfony/process",
-            "version": "v6.2.11",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "97ae9721bead9d1a39b5650e2f4b7834b93b539c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/97ae9721bead9d1a39b5650e2f4b7834b93b539c",
-                "reference": "97ae9721bead9d1a39b5650e2f4b7834b93b539c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Process\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Executes commands in sub-processes",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/process/tree/v6.2.11"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-05-19T07:42:48+00:00"
         },
         {
             "name": "ta-tikoma/phpunit-architecture-test",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,3 +8,4 @@ parameters:
     ignoreErrors:
         - '#Function [a-zA-Z0-9\\:()]+ has no return type specified.#'
         - '~^Parameter #1 \$value of function intval expects array\|bool\|float\|int\|resource\|string\|null, mixed given\.$~'
+        - '~^Parameter #2 \$string of function explode expects string, mixed given\.$~'

--- a/src/Actions/GitDirtyFiles.php
+++ b/src/Actions/GitDirtyFiles.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace LaraDumps\LaraDumpsCore\Actions;
+
+use Symfony\Component\Process\Process;
+
+final class GitDirtyFiles
+{
+    /**
+     * @internal
+     * Code snippet taken from laravel/pint
+     * url: https://github.com/laravel/pint/pull/130
+     */
+    public static function run(): array
+    {
+        $process = new Process(['git', 'status', '--short', '--', '*.php']);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            return [];
+        }
+
+        $output = $process->getOutput();
+        $lines  = preg_split('/\R+/', $output, -1, PREG_SPLIT_NO_EMPTY);
+        $files  = [];
+
+        foreach ($lines as $file) {
+            $file     = strval($file);
+            $fileName = substr($file, 3);
+            $status   = substr($file, 0, 3);
+
+            if (!empty($status) && str_ends_with($status, '  ')) {
+                $status = trim($status);
+
+                if ($status !== 'D') {
+                    if ($status === 'R') {
+                        $fileName = substr($fileName, strpos($fileName, ' -> ') + 4);
+                    }
+
+                    $files[] = getcwd() . '/' . $fileName;
+                }
+            }
+        }
+
+        return $files;
+    }
+}

--- a/src/Actions/GitDirtyFiles.php
+++ b/src/Actions/GitDirtyFiles.php
@@ -21,7 +21,7 @@ final class GitDirtyFiles
         }
 
         $output = $process->getOutput();
-        $lines  = preg_split('/\R+/', $output, -1, PREG_SPLIT_NO_EMPTY);
+        $lines  = (array) preg_split('/\R+/', $output, -1, PREG_SPLIT_NO_EMPTY);
         $files  = [];
 
         foreach ($lines as $file) {

--- a/src/Actions/GitDirtyFiles.php
+++ b/src/Actions/GitDirtyFiles.php
@@ -29,7 +29,7 @@ final class GitDirtyFiles
             $fileName = substr($file, 3);
             $status   = substr($file, 0, 3);
 
-            if (!empty($status) && str_ends_with($status, '  ')) {
+            if (!empty($status) && str_ends_with($status, ' ')) {
                 $status = trim($status);
 
                 if ($status !== 'D') {

--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -48,7 +48,7 @@ class CheckCommand extends Command
             return Command::FAILURE;
         }
 
-        $output->writeln('    <info>Laradumps is searching for words used in debugging in: ' . $input->getOption('dir') . '</info>');
+        $output->writeln('    <info>LaraDumps is searching for words used in debugging in: ' . $input->getOption('dir') . '</info>');
 
         if (!empty($input->getOption('dirty'))) {
             $dirtyFiles = GitDirtyFiles::run();
@@ -172,7 +172,7 @@ HTML);
         if (($total = count($matches)) > 0) {
             $totalFiles = count(array_unique(array_column($matches, 'realPath')));
 
-            $errorMessage = ($totalFiles === 1) ? 'error' : 'errors';
+            $errorMessage = ($total === 1) ? 'error' : 'errors';
             $fileMessage  = ($totalFiles === 1) ? 'file' : 'files';
 
             $message = '[ERROR] Found ' . $total . ' ' . $errorMessage . ' / ' . $totalFiles . ' ' . $fileMessage;

--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace LaraDumps\LaraDumpsCore\Commands;
+
+use Dotenv\Dotenv;
+use Exception;
+use LaraDumps\LaraDumpsCore\Actions\{GitDirtyFiles, MakeFileHandler};
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\{InputArgument, InputInterface};
+use Symfony\Component\Console\Output\OutputInterface;
+
+use Symfony\Component\Finder\Finder;
+
+use function Termwind\{render, renderUsing};
+
+#[AsCommand(
+    name: 'check',
+    description: 'Check if you forgot any ds() in your files',
+    hidden: false
+)]
+class CheckCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this
+            ->addOption('dirty', 'd', InputArgument::OPTIONAL);
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $dotenv = Dotenv::createImmutable(appBasePath(), '.env');
+        $dotenv->load();
+
+        $dirtyFiles = [];
+
+        if (!empty($input->getOption('dirty'))) {
+            $dirtyFiles = GitDirtyFiles::run();
+
+            if (empty($dirtyFiles)) {
+                render(<<<HTML
+<div class="mx-1">
+    <div class="flex space-x-1">
+        <span class="flex-1 content-repeat-[─] text-gray"></span>
+    </div>
+    <div>
+        <span>
+            <div class="flex space-x-2 mx-1 mb-1">
+                 <span class="px-2 bg-green text-white uppercase font-bold">
+                      ✓ SUCCESS
+                 </span>
+            </div>
+        </span>
+    </div>
+</div>
+HTML);
+
+                return Command::SUCCESS;
+            }
+        }
+
+        $ignoreLineWhenContainsText = $this->prepareTextToIgnore();
+
+        $textToSearch = $this->prepareTextToSearch();
+
+        renderUsing($output);
+
+        $matches = [];
+
+        $finder = new Finder();
+
+        $finder->files()->in($this->prepareDirectories());
+
+        $progressBar = new ProgressBar($output, count($dirtyFiles) ?: $finder->count());
+
+        $output->writeln('');
+
+        foreach ($finder as $file) {
+            if ($dirtyFiles && !in_array($file->getRealPath(), $dirtyFiles)) {
+                continue;
+            }
+
+            $progressBar->advance();
+
+            /** @var string[] $contents */
+            $contents = file($file->getRealPath());
+
+            foreach ($contents as $line => $lineContent) {
+                $contains = false;
+                $ignore   = false;
+
+                /** @var string[] $ignoreLineWhenContainsText */
+                foreach ($ignoreLineWhenContainsText as $text) {
+                    if (strpos(strtolower($lineContent), strtolower($text))) {
+                        $ignore = true;
+
+                        break;
+                    }
+                }
+
+                /** @var string[] $textToSearch */
+                foreach ($textToSearch as $search) {
+                    $search = ' ' . ltrim($search); // maintaining compatiblity with V1.0.2;
+
+                    if (strpos($lineContent, $search)
+                        || strpos($lineContent, '@' . ltrim($search))
+                        || strpos($lineContent, '//' . ltrim($search))
+                        || strpos($lineContent, '->' . ltrim($search))
+                    ) {
+                        $contains = true;
+
+                        break;
+                    }
+                }
+
+                if ($contains && !$ignore) {
+                    $matches[] = $this->saveContent($file, $lineContent, $line);
+                }
+            }
+        }
+
+        $output->writeln('');
+        $output->writeln('');
+
+        foreach ($matches as $iterator => $content) {
+            $output->writeln(
+                ' ' . ($iterator + 1)
+                . '<href=' . $content['link'] . '>  '
+                . $content['realPath']
+                . ':'
+                . $content['line']
+                . '</>'
+            );
+
+            $line    = $content['line'] - 2;
+            $content = $content['content'];
+
+            render(<<<HTML
+            <div class="space-x-1 mx-2 mb-1">
+                <code line="$line" start-line="$line">
+                    $content
+                </code>
+            </div>
+            HTML);
+        }
+
+        $progressBar->finish();
+
+        $output->writeln('');
+
+        if (($total = count($matches)) > 0) {
+            $totalFiles = count(array_unique(array_column($matches, 'realPath')));
+
+            $errorMessage = ($totalFiles === 1) ? 'error' : 'errors';
+            $fileMessage  = ($totalFiles === 1) ? 'file' : 'files';
+
+            $message = '[ERROR] Found ' . $total . ' ' . $errorMessage . ' / ' . $totalFiles . ' ' . $fileMessage;
+
+            render(
+                <<<HTML
+<div class="mx-1">
+    <div class="flex space-x-1">
+        <span class="flex-1 content-repeat-[─] text-gray"></span>
+    </div>
+    <div>
+        <span>
+            <div class="flex space-x-2 mx-1 mb-1">
+                 <span class="p-2 bg-red text-white">
+                 $message
+                 </span>
+            </div>
+        </span>
+    </div>
+</div>
+HTML
+            );
+
+            return Command::FAILURE;
+        }
+
+        render(<<<HTML
+            <div class="mx-1">
+                No ds() found.
+                <div class="flex space-x-1">
+                    <span class="flex-1 content-repeat-[─] text-gray"></span>
+                </div>
+                <div>
+                    <span>
+                        <div class="flex space-x-2 mx-1 mb-1">
+                            <span class="px-2 bg-green text-white uppercase font-bold">
+                                 ✓ SUCCESS
+                            </span>
+                        </div>
+                    </span>
+                </div>
+            </div>
+        HTML);
+
+        return Command::SUCCESS;
+    }
+
+    private function prepareDirectories(): array
+    {
+        $array = [];
+
+        foreach (explode(",", $_ENV['DS_CHECK_IN_DIR']) as $dir) {
+            $array[] = appBasePath() . trim($dir);
+        }
+
+        return $array;
+    }
+
+    private function prepareTextToSearch(): array
+    {
+        $array = [];
+
+        foreach (explode(",", $_ENV['DS_CHECK_FOR']) as $search) {
+            $array[] = appBasePath() . trim($search);
+        }
+
+        return $array;
+    }
+
+    private function prepareTextToIgnore(): array
+    {
+        $array = [];
+
+        foreach (explode(",", $_ENV['DS_CHECK_IGNORE']) as $search) {
+            $array[] = appBasePath() . trim($search);
+        }
+
+        return $array;
+    }
+
+    private function saveContent(\SplFileInfo $file, string $lineContent, int $line): array
+    {
+        /** @var array $fileContents */
+        $fileContents = file($file->getRealPath());
+
+        $partialContent = $fileContents[$line - 2] ?? '';
+        $partialContent .= $fileContents[$line - 1] ?? '';
+
+        $partialContent .= $lineContent;
+        $partialContent .= $fileContents[$line + 1] ?? '';
+
+        return [
+            'line'     => $line + 1,
+            'file'     => str_replace(appBasePath() . '/', '', $file->getRealPath()),
+            'realPath' => 'file:///' . $file->getRealPath(),
+            'link'     => MakeFileHandler::handle([
+                'file' => $file->getRealPath(), 'line' => $line + 1,
+            ]),
+            'content' => $partialContent,
+        ];
+    }
+}

--- a/tests/Feature/CheckCommandTest.php
+++ b/tests/Feature/CheckCommandTest.php
@@ -27,7 +27,7 @@ it('show message if variable ... is empty', function () {
     $output = $commandTester->getDisplay();
 
     expect($output)
-        ->toContain('Whoops. Specify the folders you need to search in DS_CHECK_IN_DIR in the comma separated .env file');
+        ->toContain('Whoops. Specify the folders you need to search in --dir option in the comma separated .env file');
 });
 
 it('check command work property', function () {
@@ -41,7 +41,7 @@ it('check command work property', function () {
     expect($output)
         ->toContain('LaraDumps is searching for words used in debugging in: ' . sprintf('tests%sFixtures', DIRECTORY_SEPARATOR))
         ->and($output)
-        ->not->toContain('Whoops. Specify the folders you need to search in DS_CHECK_IN_DIR in the comma separated .env file')
+        ->not->toContain('Whoops. Specify the folders you need to search in --dir option in the comma separated .env file')
         ->toContain('1/3')
         ->toContain(
             'ds(\'this is a function to check!\')',
@@ -67,7 +67,7 @@ it('check command with "dump", "dd" work property', function () {
     expect($output)
         ->toContain('LaraDumps is searching for words used in debugging in: ' . sprintf('tests%sFixtures', DIRECTORY_SEPARATOR))
         ->and($output)
-        ->not->toContain('Whoops. Specify the folders you need to search in DS_CHECK_IN_DIR in the comma separated .env file')
+        ->not->toContain('Whoops. Specify the folders you need to search in --dir option in the comma separated .env file')
         ->toContain('1/3')
         ->toContain(
             'dump(\'this is a function to check!\')',
@@ -88,7 +88,7 @@ it('check command without "dump", "dd" work property', function () {
     expect($output)
         ->toContain('LaraDumps is searching for words used in debugging in: ' . sprintf('tests%sFixtures', DIRECTORY_SEPARATOR))
         ->and($output)
-        ->not->toContain('Whoops. Specify the folders you need to search in DS_CHECK_IN_DIR in the comma separated .env file')
+        ->not->toContain('Whoops. Specify the folders you need to search in --dir option in the comma separated .env file')
         ->toContain('1/3')
         ->toContain(
             'ds(\'this is a function to check!\');',

--- a/tests/Feature/CheckCommandTest.php
+++ b/tests/Feature/CheckCommandTest.php
@@ -32,16 +32,14 @@ it('show message if variable ... is empty', function () {
 
 it('check command work property', function () {
     $commandTester = startCommandApplication([
-        '--dir'          => 'tests/Fixtures',
-        '--ignore-files' => 'tests/Fixtures/ds_env, tests/Fixtures/AnotherFunctionsToCheck.php',
+        '--dir'          => sprintf('tests%sFixtures', DIRECTORY_SEPARATOR),
+        '--ignore-files' => vsprintf('tests%sFixtures%sds_env, tests%sFixtures%sAnotherFunctionsToCheck.php', [DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR]),
     ]);
 
     $output = $commandTester->getDisplay();
 
-    dump($output);
-
     expect($output)
-        ->toContain('Laradumps is searching for words used in debugging in: tests/Fixtures')
+        ->toContain('LaraDumps is searching for words used in debugging in: ' . sprintf('tests%sFixtures', DIRECTORY_SEPARATOR))
         ->and($output)
         ->not->toContain('Whoops. Specify the folders you need to search in DS_CHECK_IN_DIR in the comma separated .env file')
         ->toContain('1/3')
@@ -54,20 +52,20 @@ it('check command work property', function () {
             'dd(\'this is a function to check!\')',
             '//ds(\'this is a function to check!\')'
         )
-        ->toContain('[ERROR] Found 2 error / 1 file');
+        ->toContain('[ERROR] Found 2 errors / 1 file');
 });
 
 it('check command with "dump", "dd" work property', function () {
     $commandTester = startCommandApplication([
-        '--dir'          => 'tests/Fixtures',
-        '--ignore-files' => 'tests/Fixtures/ds_env, tests/Fixtures/ExampleClassToCheck.php',
+        '--dir'          => sprintf('tests%sFixtures', DIRECTORY_SEPARATOR),
+        '--ignore-files' => vsprintf('tests%sFixtures%sds_env, tests%sFixtures%sExampleClassToCheck.php', [DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR]),
         '--text'         => 'dump,dd',
     ]);
 
     $output = $commandTester->getDisplay();
 
     expect($output)
-        ->toContain('Laradumps is searching for words used in debugging in: tests/Fixtures')
+        ->toContain('LaraDumps is searching for words used in debugging in: ' . sprintf('tests%sFixtures', DIRECTORY_SEPARATOR))
         ->and($output)
         ->not->toContain('Whoops. Specify the folders you need to search in DS_CHECK_IN_DIR in the comma separated .env file')
         ->toContain('1/3')
@@ -76,19 +74,19 @@ it('check command with "dump", "dd" work property', function () {
             'dd(\'this is a function to check!\')',
             '//dd(\'this is a function to check!\')'
         )
-        ->toContain('[ERROR] Found 3 error / 1 file');
+        ->toContain('[ERROR] Found 3 errors / 1 file');
 });
 
 it('check command without "dump", "dd" work property', function () {
     $commandTester = startCommandApplication([
-        '--dir'          => 'tests/Fixtures',
-        '--ignore-files' => 'tests/Fixtures/ds_env, tests/Fixtures/AnotherFunctionsToCheck.php',
+        '--dir'          => sprintf('tests%sFixtures', DIRECTORY_SEPARATOR),
+        '--ignore-files' => vsprintf('tests%sFixtures%sds_env, tests%sFixtures%sAnotherFunctionsToCheck.php', [DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR]),
     ]);
 
     $output = $commandTester->getDisplay();
 
     expect($output)
-        ->toContain('Laradumps is searching for words used in debugging in: tests/Fixtures')
+        ->toContain('LaraDumps is searching for words used in debugging in: tests/Fixtures')
         ->and($output)
         ->not->toContain('Whoops. Specify the folders you need to search in DS_CHECK_IN_DIR in the comma separated .env file')
         ->toContain('1/3')
@@ -96,5 +94,5 @@ it('check command without "dump", "dd" work property', function () {
             'ds(\'this is a function to check!\');',
             ' @ds("this is a function to check!")',
         )
-        ->toContain('[ERROR] Found 2 error / 1 file');
+        ->toContain('[ERROR] Found 2 errors / 1 file');
 });

--- a/tests/Feature/CheckCommandTest.php
+++ b/tests/Feature/CheckCommandTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use LaraDumps\LaraDumpsCore\Commands\CheckCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+function startCommandApplication(array $arguments): CommandTester
+{
+    $application = new Application();
+    $application->add(new CheckCommand());
+
+    $command = $application->find('check');
+
+    $commandTester = new CommandTester($command);
+
+    $commandTester->execute([
+        'command' => $command->getName(),
+        ...$arguments,
+    ]);
+
+    return $commandTester;
+}
+
+it('show message if variable ... is empty', function () {
+    $commandTester = startCommandApplication([]);
+
+    $output = $commandTester->getDisplay();
+
+    expect($output)
+        ->toContain('Whoops. Specify the folders you need to search in DS_CHECK_IN_DIR in the comma separated .env file');
+});
+
+it('check command work property', function () {
+    $commandTester = startCommandApplication([
+        '--dir'          => 'tests/Fixtures',
+        '--ignore-files' => 'tests/Fixtures/ds_env, tests/Fixtures/AnotherFunctionsToCheck.php',
+    ]);
+
+    $output = $commandTester->getDisplay();
+
+    dump($output);
+
+    expect($output)
+        ->toContain('Laradumps is searching for words used in debugging in: tests/Fixtures')
+        ->and($output)
+        ->not->toContain('Whoops. Specify the folders you need to search in DS_CHECK_IN_DIR in the comma separated .env file')
+        ->toContain('1/3')
+        ->toContain(
+            'ds(\'this is a function to check!\')',
+            '@ds("this is a function to check!")',
+        )
+        ->not->toContain(
+            'dump(\'this is a function to check!\')',
+            'dd(\'this is a function to check!\')',
+            '//ds(\'this is a function to check!\')'
+        )
+        ->toContain('[ERROR] Found 2 error / 1 file');
+});
+
+it('check command with "dump", "dd" work property', function () {
+    $commandTester = startCommandApplication([
+        '--dir'          => 'tests/Fixtures',
+        '--ignore-files' => 'tests/Fixtures/ds_env, tests/Fixtures/ExampleClassToCheck.php',
+        '--text'         => 'dump,dd',
+    ]);
+
+    $output = $commandTester->getDisplay();
+
+    expect($output)
+        ->toContain('Laradumps is searching for words used in debugging in: tests/Fixtures')
+        ->and($output)
+        ->not->toContain('Whoops. Specify the folders you need to search in DS_CHECK_IN_DIR in the comma separated .env file')
+        ->toContain('1/3')
+        ->toContain(
+            'dump(\'this is a function to check!\')',
+            'dd(\'this is a function to check!\')',
+            '//dd(\'this is a function to check!\')'
+        )
+        ->toContain('[ERROR] Found 3 error / 1 file');
+});
+
+it('check command without "dump", "dd" work property', function () {
+    $commandTester = startCommandApplication([
+        '--dir'          => 'tests/Fixtures',
+        '--ignore-files' => 'tests/Fixtures/ds_env, tests/Fixtures/AnotherFunctionsToCheck.php',
+    ]);
+
+    $output = $commandTester->getDisplay();
+
+    expect($output)
+        ->toContain('Laradumps is searching for words used in debugging in: tests/Fixtures')
+        ->and($output)
+        ->not->toContain('Whoops. Specify the folders you need to search in DS_CHECK_IN_DIR in the comma separated .env file')
+        ->toContain('1/3')
+        ->toContain(
+            'ds(\'this is a function to check!\');',
+            ' @ds("this is a function to check!")',
+        )
+        ->toContain('[ERROR] Found 2 error / 1 file');
+});

--- a/tests/Feature/CheckCommandTest.php
+++ b/tests/Feature/CheckCommandTest.php
@@ -86,7 +86,7 @@ it('check command without "dump", "dd" work property', function () {
     $output = $commandTester->getDisplay();
 
     expect($output)
-        ->toContain('LaraDumps is searching for words used in debugging in: tests/Fixtures')
+        ->toContain('LaraDumps is searching for words used in debugging in: ' . sprintf('tests%sFixtures', DIRECTORY_SEPARATOR))
         ->and($output)
         ->not->toContain('Whoops. Specify the folders you need to search in DS_CHECK_IN_DIR in the comma separated .env file')
         ->toContain('1/3')

--- a/tests/Fixtures/AnotherFunctionsToCheck.php
+++ b/tests/Fixtures/AnotherFunctionsToCheck.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Fixtures;
+
+class AnotherFunctionsToCheck
+{
+    public function function1()
+    {
+        dump('this is a function to check!');
+    }
+
+    public function function2()
+    {
+        dd('this is a function to check!');
+    }
+
+    public function function3()
+    {
+        //dd('this is a function to check!');
+    }
+}

--- a/tests/Fixtures/ExampleClassToCheck.php
+++ b/tests/Fixtures/ExampleClassToCheck.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Fixtures;
+
+class ExampleClassToCheck
+{
+    public function function1()
+    {
+        ds('this is a function to check!');
+    }
+
+    public function function2()
+    {
+        return ' @ds("this is a function to check!")';
+    }
+}

--- a/tests/Fixtures/ds_env
+++ b/tests/Fixtures/ds_env
@@ -9,10 +9,6 @@ DS_AUTO_INVOKE_APP=true
 # ******* File Handler *******
 DS_FILE_HANDLER="phpstorm://open?file={filepath}&line={line}"
 DS_PROJECT_PATH="/Users/jamesbond/bomb-disarmer"
-# ******* DS Check *******
-DS_CHECK_FOR="ds, dsq, dsd, ds1, ds2, ds3, ds4, ds5, dsAutoClearOnPageReload"
-DS_CHECK_IN_DIR="app,routes,resources,juca"
-DS_CHECK_IGNORE="foods,ads"
 # ******* Hide Routes *******
 DS_IGNORE_ROUTES="debugbar,ignition,horizon,livewire"
 DS_SOME_KEY=


### PR DESCRIPTION
This Pr implements the "_check_" command that was previously in the laradumps repo. It is now part of the core by default.

Some changes regarding php artisan ds:check:

* Does not require environment variables or configuration files. Only via argument in the terminal:

```bash
vendor/bin/laradumps check --dir=app,routes,config --text=dump,dd // ds,dsq,dsd,ds1,ds2,ds3,ds4,ds5,dump,dd
```

* Some words are default: `ds,dsq,dsd,ds1,ds2,ds3,ds4,ds5`
* Another options:
```
--dirty // Search only files that are dirty in git
--ignore // Directories to be ignored separated by comma
--ignore-files // Files that will be ignored separated by a comma
stop-on-failure // Stop the search if a match is found
```