### PR TITLE
Update request timeout

### DIFF
--- a/src/Actions/SendPayload.php
+++ b/src/Actions/SendPayload.php
@@ -41,7 +41,7 @@ final class SendPayload
             CURLOPT_POSTFIELDS        => json_encode($payload),
             CURLOPT_URL               => $this->appUrl,
             CURLOPT_TIMEOUT           => 1,
-            CURLOPT_CONNECTTIMEOUT_MS => 10,
+            CURLOPT_CONNECTTIMEOUT_MS => 100,
         ]);
 
         $exec = curl_exec($curlRequest);


### PR DESCRIPTION
I couldn't get the App to work. Digg'd a little and found out that the timeout was holding me off.

What I did debug was:
1. CURL error:
```Failed to connect to 0.0.0.0 port 9191 after 10 ms: Timeout was reached```
2. while the port was open on my Mac:
```
proto: tcp4     addr.port: *.9191                                 pid: 95422    name: /Applications/LaraDumps.app/Contents/Frameworks/LaraDumps Helper (Renderer).app/Contents/MacOS/LaraDumps Helper (Renderer)
```
While extending the timeout I got messages in the LaraDumps application.
Maybe you can consider to update the timeout please?
Thanks,
Edwin