### PR TITLE
Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         "symfony/console": "^6.4|^7.0",
         "symfony/process": "^6.4|^7.0",
         "symfony/finder": "^6.4|^7.0",
-        "nesbot/carbon": "^2.72.1",
-        "nunomaduro/termwind": "^1.15.1"
+        "nesbot/carbon": "^2.72",
+        "nunomaduro/termwind": "^1.15|^2.0"
     },
     "require-dev": {
         "laravel/pint": "^1.13.7",


### PR DESCRIPTION
Fix - laravel/framework dev-master requires nunomaduro/termwind ^2.0 -> satisfiable by nunomaduro/termwind[v2.0.0, 2.x-dev].
