### PR TITLE
Enhance appBasePath() to handle multiple end directories

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -8,11 +8,10 @@ if (!function_exists('appBasePath')) {
     {
         $basePath = rtrim(strval(getcwd()), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
 
-        $possibleEndDirs = ['public', 'pub', 'wp-admin'];
-
-        foreach ($possibleEndDirs as $dir) {
+        foreach (['public', 'pub', 'wp-admin'] as $dir) {
             if (str_ends_with($basePath, $dir . DIRECTORY_SEPARATOR)) {
                 $basePath = substr($basePath, 0, -strlen($dir . DIRECTORY_SEPARATOR));
+
                 break;
             }
         }

--- a/src/functions.php
+++ b/src/functions.php
@@ -8,8 +8,13 @@ if (!function_exists('appBasePath')) {
     {
         $basePath = rtrim(strval(getcwd()), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
 
-        if (str_contains($basePath, 'public')) {
-            $basePath = str_replace('public' . DIRECTORY_SEPARATOR, '', $basePath);
+        $possibleEndDirs = ['public', 'pub', 'wp-admin'];
+
+        foreach ($possibleEndDirs as $dir) {
+            if (str_ends_with($basePath, $dir . DIRECTORY_SEPARATOR)) {
+                $basePath = substr($basePath, 0, -strlen($dir . DIRECTORY_SEPARATOR));
+                break;
+            }
         }
 
         return $basePath;


### PR DESCRIPTION
This PR updates the appBasePath() function to:
- Check for multiple possible end directory names ('public', 'pub', 'wp-admin')

This change improves compatibility with various project structures (e.g., Laravel, Magento 2, WordPress). 
Also fixes https://github.com/laradumps/laradumps-core/issues/7