### PR TITLE
Improve Laravel Octane compatibility

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -6,14 +6,9 @@ use LaraDumps\LaraDumpsCore\LaraDumps;
 if (!function_exists('appBasePath')) {
     function appBasePath(): string
     {
-        $currentWorkingDirectory = getcwd();
-        if (isset($_SERVER['LARAVEL_OCTANE']) && intval($_SERVER['LARAVEL_OCTANE']) === 1) {
-            // Use base_path to get the actual project path, as octane is running inside its vendor folder.
-            // We can use globally registered laravel functions when octane was detected.
-            $currentWorkingDirectory = base_path();
-        }
+        $pwd = defined('LARAVEL_START') || isset($_SERVER['LARAVEL_OCTANE']) ? app()->basePath() : getcwd();
 
-        $basePath = rtrim(strval($currentWorkingDirectory), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        $basePath = rtrim($pwd, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
 
         foreach (['public', 'pub', 'wp-admin'] as $dir) {
             if (str_ends_with($basePath, $dir . DIRECTORY_SEPARATOR)) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -6,7 +6,14 @@ use LaraDumps\LaraDumpsCore\LaraDumps;
 if (!function_exists('appBasePath')) {
     function appBasePath(): string
     {
-        $basePath = rtrim(strval(getcwd()), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        $currentWorkingDirectory = getcwd();
+        if (isset($_SERVER['LARAVEL_OCTANE']) && intval($_SERVER['LARAVEL_OCTANE']) === 1) {
+            // Use base_path to get the actual project path, as octane is running inside its vendor folder.
+            // We can use globally registered laravel functions when octane was detected.
+            $currentWorkingDirectory = base_path();
+        }
+
+        $basePath = rtrim(strval($currentWorkingDirectory), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
 
         foreach (['public', 'pub', 'wp-admin'] as $dir) {
             if (str_ends_with($basePath, $dir . DIRECTORY_SEPARATOR)) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -6,7 +6,8 @@ use LaraDumps\LaraDumpsCore\LaraDumps;
 if (!function_exists('appBasePath')) {
     function appBasePath(): string
     {
-        $pwd = defined('LARAVEL_START') || isset($_SERVER['LARAVEL_OCTANE']) ? app()->basePath() : getcwd();
+        $pwd = (defined('LARAVEL_START') || isset($_SERVER['LARAVEL_OCTANE'])) && function_exists('app')
+            ? app()->basePath() : getcwd();
 
         $basePath = rtrim($pwd, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
 


### PR DESCRIPTION
Hi,

I've encountered problems when trying to use laradumps inside of a project using Laravel Octane with the openswoole backend. It looks like the working directory gets shifted inside of vendor/laravel/octane/bin when using the (open)swoole beackend inside Octane. That means that getcwd will return the path inside of the vendor folder and laradumps will not find the laradumps.yaml configuration file. 

Laravel (Octane) uses a different method to resolve the current working directory, therefore I just tap into the original base_path function and it will work.

Feel free to request changes if you think my solution is too hacky 😄