### PR TITLE
Fix times being initialized in the system's timezone in tests

### DIFF
--- a/tests/Feature/Actions/ConvertArrayToPhpSyntaxTest.php
+++ b/tests/Feature/Actions/ConvertArrayToPhpSyntaxTest.php
@@ -207,7 +207,7 @@ it('handles mixed content', function (): void {
 });
 
 it('handles new DateTimeInterface', function (): void {
-    $dateTime = new DateTime('2023-10-01 12:00:00');
+    $dateTime = new DateTime('2023-10-01 12:00:00', new DateTimeZone('utc'));
 
     $input = [
         'date' => $dateTime,
@@ -219,7 +219,7 @@ it('handles new DateTimeInterface', function (): void {
 });
 
 it('handles new CarbonInterface', function (): void {
-    $carbon = new DateTime('2023-10-01 12:00:00');
+    $carbon = new DateTime('2023-10-01 12:00:00', new DateTimeZone('utc'));
 
     $input = [
         'date' => $carbon,


### PR DESCRIPTION
This is a followup to #64 and #71.

#71 standardized the output, but if the system time isn't UTC, then the times that get output don't match in the test. This just manually sets UTC on the dates being tested.