### PR TITLE
Add "extension" option to "check" command

### DIFF
--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -33,6 +33,7 @@ class CheckCommand extends Command
             ->addOption('dir', null, InputArgument::OPTIONAL, 'Directories that will be filtered separated by comma')
             ->addOption('ignore', null, InputArgument::OPTIONAL, 'Directories to be ignored separated by comma')
             ->addOption('text', null, InputArgument::OPTIONAL, 'Texts that will be searched separated by a comma')
+            ->addOption('extension', null, InputArgument::OPTIONAL, 'File extensions that will be searched separated by a comma')
             ->addOption('ignore-files', null, InputArgument::OPTIONAL, 'Files that will be ignored separated by a comma')
             ->addArgument('stop-on-failure', InputArgument::OPTIONAL, 'Stop the search if a match is found')
             ->addOption('exactly', null, InputArgument::OPTIONAL, 'Search for exact occurrences');
@@ -81,13 +82,22 @@ class CheckCommand extends Command
             }
         }
 
+        $extensions = ['php'];
+
+        if (!empty($input->getOption('extension'))) {
+            $extensions = explode(',', $input->getOption('extension'));
+        }
+
         $matches = [];
 
         $finder = (new Finder())->files()
             ->ignoreVCS(true)
             ->exclude('node_modules')
-            ->name('*.php')
             ->in($this->prepareDirectories($input));
+
+        foreach ($extensions as $extension) {
+            $finder->name("*.$extension");
+        }
 
         $progressBar = new ProgressBar($output, count($dirtyFiles) ?: $finder->count());
 

--- a/tests/Feature/CheckCommandTest.php
+++ b/tests/Feature/CheckCommandTest.php
@@ -135,3 +135,24 @@ it('checks command with "dd" and "--exactly" works property', function () {
         )
         ->toContain('ERROR - Found 6 errors / 2 files');
 });
+
+it('check command with custom extensions works properly', function () {
+    $commandTester = startCommandApplication([
+        '--dir'          => sprintf('tests%sFixtures', DIRECTORY_SEPARATOR),
+        '--ignore-files' => vsprintf('tests%sFixtures%sds_env, tests%sFixtures%sAnotherFunctionsToCheck.php', [DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR]),
+        '--extension'    => 'php,twig',
+    ]);
+
+    $output = $commandTester->getDisplay();
+
+    expect($output)
+        ->toContain('LaraDumps is searching for words used in debugging in: ' . sprintf('tests%sFixtures', DIRECTORY_SEPARATOR))
+        ->and($output)
+        ->not->toContain('Whoops. Specify the folders you need to search in --dir option in the comma separated')
+        ->toContain('1/3')
+        ->toContain(
+            '{{ ds(\'this is a twig function to check!\')',
+            '{{ds(\'this is a twig function to check!\')',
+        )
+        ->toContain('ERROR - Found 7 errors / 3 files');
+});

--- a/tests/Fixtures/template-to-check.twig
+++ b/tests/Fixtures/template-to-check.twig
@@ -1,0 +1,5 @@
+{{ ds('this is a twig function to check!') }}
+
+
+
+{{ds('this is a twig function to check!')}}


### PR DESCRIPTION
This adds the ability to check files with extensions other than ".php".

I'm submitting this because I've created a "ds" function for Twig , so I can easily debug templates in CraftCMS, and I accidentally pushed one to staging. Naturally, a 500 showed up.