### PR TITLE
fix: create DateTime from non-locale aware float

### DIFF
--- a/src/Payloads/BenchmarkPayload.php
+++ b/src/Payloads/BenchmarkPayload.php
@@ -41,9 +41,9 @@ class BenchmarkPayload extends Payload
             $label     = is_int($label) ? 'Closure ' . $label : $label;
 
             /** @var \DateTime $startDateTime */
-            $startDateTime = \DateTime::createFromFormat('U.u', sprintf('%.6f', $startsAt));
+            $startDateTime = \DateTime::createFromFormat('U.u', sprintf('%.6F', $startsAt));
             /** @var \DateTime $endDateTime */
-            $endDateTime = \DateTime::createFromFormat('U.u', sprintf('%.6f', $endsAt));
+            $endDateTime = \DateTime::createFromFormat('U.u', sprintf('%.6F', $endsAt));
 
             $results[$label] = [
                 'Start Time' => $startDateTime->format('Y-m-d H:i:s'),


### PR DESCRIPTION
This small PR fixes an error related to localization.

When running this code

```php
        ds()->benchmark(
            function () {
                sleep(2);

                return 'First';
            },
            function () {
                sleep(1);

                return 'Second';
            }
        );
```

for example, in a Laravel app where locale has been set to `IT` (`APP_LOCALE=it` in `.env`), benchmark cannot be calculated:

```
  Call to a member function format() on false

  at vendor/laradumps/laradumps-core/src/Payloads/BenchmarkPayload.php:49
     45▕             /** @var \DateTime $endDateTime */
     46▕             $endDateTime = \DateTime::createFromFormat('U.u', sprintf('%.6f', $endsAt));
     47▕
     48▕             $results[$label] = [
  ➜  49▕                 'Start Time' => $startDateTime->format('Y-m-d H:i:s'),
     50▕                 'End Time'   => $endDateTime->format('Y-m-d H:i:s'),
     51▕                 'Total Time' => $totalTime . ' ms',
     52▕                 'Result'     => $result,
     53▕             ];

```

This happens because `sprintf` with `f` formatter returns a locale aware float, with `,` as separator (due to Italian localization):

```php
$startsAt = microtime(true);
sprintf("%.6f", $startsAt); // It returns "1764493970,866050" instead of "1764493970.866050"
```

This way, both `$startDateTime` and `$endDateTime` will be set to `false`.

Using `F` formatter should fix that, since _the argument is treated as a float and presented as a floating-point number (non-locale aware)_ (source: https://www.php.net/manual/en/function.sprintf.php).

Thanks for making Laradumps open-source! ❤️