### PR TITLE
Add original dump content

### DIFF
--- a/src/Payloads/BenchmarkPayload.php
+++ b/src/Payloads/BenchmarkPayload.php
@@ -11,6 +11,7 @@ class BenchmarkPayload extends Payload
         private string $screen = 'home',
         private string $label = 'Benchmark',
     ) {
+        $this->setOriginalContent($this->args);
     }
 
     public function type(): string

--- a/src/Payloads/ColorPayload.php
+++ b/src/Payloads/ColorPayload.php
@@ -9,6 +9,7 @@ class ColorPayload extends Payload
         private string $screen = 'home',
         private string $label = '',
     ) {
+        $this->setOriginalContent($this->color);
     }
 
     public function type(): string

--- a/src/Payloads/DumpPayload.php
+++ b/src/Payloads/DumpPayload.php
@@ -2,8 +2,6 @@
 
 namespace LaraDumps\LaraDumpsCore\Payloads;
 
-use LaraDumps\LaraDumpsCore\Actions\ConvertArrayToPhpSyntax;
-
 class DumpPayload extends Payload
 {
     public function __construct(
@@ -13,6 +11,7 @@ class DumpPayload extends Payload
         private string $screen = 'home',
         private string $label = '',
     ) {
+        $this->setOriginalContent($this->originalContent);
     }
 
     public function type(): string
@@ -23,9 +22,8 @@ class DumpPayload extends Payload
     public function content(): array
     {
         return [
-            'dump'             => $this->dump,
-            'original_content' => ConvertArrayToPhpSyntax::convert($this->originalContent),
-            'variable_type'    => $this->variableType,
+            'dump'          => $this->dump,
+            'variable_type' => $this->variableType,
         ];
     }
 

--- a/src/Payloads/DumpPayload.php
+++ b/src/Payloads/DumpPayload.php
@@ -2,6 +2,8 @@
 
 namespace LaraDumps\LaraDumpsCore\Payloads;
 
+use LaraDumps\LaraDumpsCore\Actions\ConvertArrayToPhpSyntax;
+
 class DumpPayload extends Payload
 {
     public function __construct(
@@ -22,8 +24,9 @@ class DumpPayload extends Payload
     public function content(): array
     {
         return [
-            'dump'          => $this->dump,
-            'variable_type' => $this->variableType,
+            'dump'             => $this->dump,
+            'original_content' => ConvertArrayToPhpSyntax::convert($this->originalContent),
+            'variable_type'    => $this->variableType,
         ];
     }
 

--- a/src/Payloads/JsonPayload.php
+++ b/src/Payloads/JsonPayload.php
@@ -20,7 +20,8 @@ class JsonPayload extends Payload
     public function content(): array
     {
         return [
-            'string' => $this->string,
+            'string'           => $this->string,
+            'original_content' => $this->string,
         ];
     }
 

--- a/src/Payloads/JsonPayload.php
+++ b/src/Payloads/JsonPayload.php
@@ -9,6 +9,7 @@ class JsonPayload extends Payload
         private string $screen = 'home',
         private string $label = '',
     ) {
+        $this->setOriginalContent($this->string);
     }
 
     public function type(): string
@@ -19,8 +20,7 @@ class JsonPayload extends Payload
     public function content(): array
     {
         return [
-            'string'           => $this->string,
-            'original_content' => $this->string,
+            'string' => $this->string,
         ];
     }
 

--- a/src/Payloads/LabelPayload.php
+++ b/src/Payloads/LabelPayload.php
@@ -10,6 +10,7 @@ class LabelPayload extends Payload
     public function __construct(
         public string $label
     ) {
+        $this->setOriginalContent($this->label);
     }
 
     public function type(): string

--- a/src/Payloads/Payload.php
+++ b/src/Payloads/Payload.php
@@ -17,6 +17,8 @@ abstract class Payload
 
     private array $codeSnippet = [];
 
+    protected mixed $originalContent = null;
+
     abstract public function type(): string;
 
     abstract public function toScreen(): array|Screen;
@@ -57,6 +59,16 @@ abstract class Payload
         $this->notificationId = $notificationId;
     }
 
+    public function setOriginalContent(mixed $originalContent): void
+    {
+        $this->originalContent = $originalContent;
+    }
+
+    public function getOriginalContent(): mixed
+    {
+        return $this->originalContent;
+    }
+
     public function ideHandle(): array
     {
         $ideHandle = new IdeHandle($this->frame);
@@ -75,13 +87,20 @@ abstract class Payload
             define('LARADUMPS_REQUEST_ID', uniqid());
         }
 
+        $content = $this->content();
+
+        // Add original_content to the payload if it's set
+        if ($this->originalContent !== null) {
+            $content['original_content'] = $this->getConvertedOriginalContent();
+        }
+
         return [
             'id'               => $this->notificationId,
             'application_path' => $this->applicationPath(),
             'request_id'       => LARADUMPS_REQUEST_ID,
             'sf_dump_id'       => $this->dumpId,
             'type'             => $this->type(),
-            $this->type()      => $this->content(),
+            $this->type()      => $content,
             'ide_handle'       => $this->ideHandle(),
             'code_snippet'     => $this->codeSnippet,
             'to_screen'        => $this->toScreen(),
@@ -97,6 +116,15 @@ abstract class Payload
         $path = Config::get('app.project_path', '');
 
         return $path;
+    }
+
+    private function getConvertedOriginalContent(): mixed
+    {
+        if ($this->originalContent === null) {
+            return null;
+        }
+
+        return \LaraDumps\LaraDumpsCore\Actions\ConvertArrayToPhpSyntax::convert($this->originalContent);
     }
 
     private function getExtraPayload(): array

--- a/src/Payloads/ScreenPayload.php
+++ b/src/Payloads/ScreenPayload.php
@@ -9,6 +9,7 @@ class ScreenPayload extends Payload
         public int $raiseIn = 0,
         public bool $newWindow = false
     ) {
+        $this->setOriginalContent($this->name);
     }
 
     public function type(): string

--- a/src/Payloads/TablePayload.php
+++ b/src/Payloads/TablePayload.php
@@ -15,6 +15,8 @@ class TablePayload extends Payload
         if (empty($this->name)) {
             $this->name = 'Table';
         }
+
+        $this->setOriginalContent($this->data);
     }
 
     public function type(): string

--- a/src/Payloads/TableV2Payload.php
+++ b/src/Payloads/TableV2Payload.php
@@ -12,6 +12,7 @@ class TableV2Payload extends Payload
         protected string $screen = 'home',
         protected string $label = 'Table',
     ) {
+        $this->setOriginalContent($this->values);
     }
 
     public function type(): string

--- a/src/Payloads/TimeTrackPayload.php
+++ b/src/Payloads/TimeTrackPayload.php
@@ -12,6 +12,7 @@ class TimeTrackPayload extends Payload
         public bool $stop = false,
         public string $screen = 'home'
     ) {
+        $this->setOriginalContent($this->reference);
     }
 
     public function type(): string

--- a/src/Payloads/ValidateStringPayload.php
+++ b/src/Payloads/ValidateStringPayload.php
@@ -15,6 +15,7 @@ class ValidateStringPayload extends Payload
         private string $screen = 'home',
         private string $label = '',
     ) {
+        $this->setOriginalContent($this->type);
     }
 
     public function type(): string

--- a/tests/Feature/OriginalContentTest.php
+++ b/tests/Feature/OriginalContentTest.php
@@ -1,0 +1,191 @@
+<?php
+
+use LaraDumps\LaraDumpsCore\Payloads\{
+    BenchmarkPayload,
+    ColorPayload,
+    DumpPayload,
+    JsonPayload,
+    LabelPayload,
+    ScreenPayload,
+    TablePayload,
+    TableV2Payload,
+    TimeTrackPayload,
+    ValidateStringPayload,
+};
+
+describe('original_content in Payloads', function () {
+    it('DumpPayload sets and retrieves original_content', function () {
+        $data    = ['name' => 'John', 'age' => 30];
+        $payload = new DumpPayload($data, $data);
+        expect($payload->getOriginalContent())->toBe($data);
+    });
+
+    it('JsonPayload sets and retrieves original_content', function () {
+        $jsonString = '{"name": "John", "age": 30}';
+        $payload    = new JsonPayload($jsonString);
+        expect($payload->getOriginalContent())->toBe($jsonString);
+    });
+
+    it('TableV2Payload sets and retrieves original_content', function () {
+        $data    = [['name' => 'John'], ['name' => 'Jane']];
+        $payload = new TableV2Payload($data);
+        expect($payload->getOriginalContent())->toBe($data);
+    });
+
+    it('TablePayload sets and retrieves original_content', function () {
+        $data    = [['name' => 'John'], ['name' => 'Jane']];
+        $payload = new TablePayload($data, 'Users');
+        expect($payload->getOriginalContent())->toBe($data);
+    });
+
+    it('BenchmarkPayload sets and retrieves original_content', function () {
+        $args    = ['test1' => fn () => 1 + 1, 'test2' => fn () => 2 + 2];
+        $payload = new BenchmarkPayload($args);
+        expect($payload->getOriginalContent())->toBe($args);
+    });
+
+    it('ColorPayload sets and retrieves original_content', function () {
+        $color   = '#FF5733';
+        $payload = new ColorPayload($color);
+        expect($payload->getOriginalContent())->toBe($color);
+    });
+
+    it('TimeTrackPayload sets and retrieves original_content', function () {
+        $reference = 'database_query';
+        $payload   = new TimeTrackPayload($reference);
+        expect($payload->getOriginalContent())->toBe($reference);
+    });
+
+    it('LabelPayload sets and retrieves original_content', function () {
+        $label   = 'My Custom Label';
+        $payload = new LabelPayload($label);
+        expect($payload->getOriginalContent())->toBe($label);
+    });
+
+    it('ScreenPayload sets and retrieves original_content', function () {
+        $screenName = 'dashboard';
+        $payload    = new ScreenPayload($screenName);
+        expect($payload->getOriginalContent())->toBe($screenName);
+    });
+
+    it('ValidateStringPayload sets and retrieves original_content', function () {
+        $type    = 'email';
+        $payload = new ValidateStringPayload($type);
+        expect($payload->getOriginalContent())->toBe($type);
+    });
+});
+
+describe('original_content edge cases', function () {
+    it('handles null original_content', function () {
+        $payload = new DumpPayload(['test' => 'data'], null);
+        expect($payload->getOriginalContent())->toBeNull();
+    });
+
+    it('handles empty array original_content', function () {
+        $payload = new DumpPayload(['test' => 'data'], []);
+        expect($payload->getOriginalContent())->toBe([]);
+    });
+
+    it('handles scalar values', function () {
+        $payload = new DumpPayload(['test' => 'data'], 'simple string');
+        expect($payload->getOriginalContent())->toBe('simple string');
+    });
+
+    it('handles boolean values', function () {
+        $payload = new DumpPayload(['test' => 'data'], true);
+        expect($payload->getOriginalContent())->toBe(true);
+    });
+
+    it('handles numeric values', function () {
+        $payload = new DumpPayload(['test' => 'data'], 42);
+        expect($payload->getOriginalContent())->toBe(42);
+    });
+
+    it('handles arrays with numeric keys', function () {
+        $data    = [1 => 'first', 2 => 'second', 3 => 'third'];
+        $payload = new DumpPayload($data, $data);
+        expect($payload->getOriginalContent())->toBe($data);
+    });
+
+    it('handles nested arrays', function () {
+        $data    = ['user' => ['name' => 'John', 'email' => 'john@example.com'], 'active' => true];
+        $payload = new DumpPayload($data, $data);
+        expect($payload->getOriginalContent())->toBe($data);
+    });
+
+    it('handles objects with toArray method', function () {
+        $data = new class () {
+            public function toArray()
+            {
+                return ['converted' => true];
+            }
+        };
+        $payload = new DumpPayload($data, $data);
+        expect($payload->getOriginalContent())->toBe($data);
+    });
+});
+
+describe('setOriginalContent method', function () {
+    it('allows setting original_content after instantiation', function () {
+        $payload = new DumpPayload(['initial' => 'data'], ['initial' => 'data']);
+        expect($payload->getOriginalContent())->toBe(['initial' => 'data']);
+
+        $payload->setOriginalContent(['updated' => 'data']);
+        expect($payload->getOriginalContent())->toBe(['updated' => 'data']);
+    });
+
+    it('allows updating original_content to null', function () {
+        $payload = new DumpPayload(['test' => 'data'], ['test' => 'data']);
+        expect($payload->getOriginalContent())->not->toBeNull();
+
+        $payload->setOriginalContent(null);
+        expect($payload->getOriginalContent())->toBeNull();
+    });
+
+    it('allows changing original_content type', function () {
+        $payload = new DumpPayload(['test' => 'data'], ['initial' => 'array']);
+
+        $payload->setOriginalContent('string value');
+        expect($payload->getOriginalContent())->toBe('string value');
+
+        $payload->setOriginalContent(123);
+        expect($payload->getOriginalContent())->toBe(123);
+
+        $payload->setOriginalContent(true);
+        expect($payload->getOriginalContent())->toBe(true);
+    });
+
+    it('works with JsonPayload', function () {
+        $payload = new JsonPayload('{"initial": "json"}');
+        expect($payload->getOriginalContent())->toBe('{"initial": "json"}');
+
+        $payload->setOriginalContent('{"updated": "json"}');
+        expect($payload->getOriginalContent())->toBe('{"updated": "json"}');
+    });
+
+    it('works with TableV2Payload', function () {
+        $initialData = [['id' => 1]];
+        $payload     = new TableV2Payload($initialData);
+        expect($payload->getOriginalContent())->toBe($initialData);
+
+        $updatedData = [['id' => 2], ['id' => 3]];
+        $payload->setOriginalContent($updatedData);
+        expect($payload->getOriginalContent())->toBe($updatedData);
+    });
+
+    it('works with all payload types', function () {
+        $payloads = [
+            'ColorPayload'          => new ColorPayload('#FF0000'),
+            'TimeTrackPayload'      => new TimeTrackPayload('query'),
+            'LabelPayload'          => new LabelPayload('label'),
+            'ScreenPayload'         => new ScreenPayload('screen'),
+            'ValidateStringPayload' => new ValidateStringPayload('email'),
+        ];
+
+        foreach ($payloads as $name => $payload) {
+            $newValue = "updated-$name";
+            $payload->setOriginalContent($newValue);
+            expect($payload->getOriginalContent())->toBe($newValue, "Failed for $name");
+        }
+    });
+});


### PR DESCRIPTION
This pull request introduces a standardized approach for managing and exposing the "original_content" property across all payload classes in the codebase. The main goal is to ensure that each payload can set, retrieve, and serialize its original content in a consistent way. This is achieved by adding new methods and logic to the base `Payload` class, updating all payload subclasses to utilize these methods, and introducing comprehensive tests to validate the new behavior.

Key changes include:

**Core implementation of original_content:**

* Added a protected `originalContent` property, along with `setOriginalContent` and `getOriginalContent` methods, to the base `Payload` class. Also introduced logic in `toArray()` to include a converted version of `original_content` in the serialized payload if it is set. The conversion uses `ConvertArrayToPhpSyntax` for consistent formatting. [[1]](diffhunk://#diff-806b0ecb862b870ebdad1147da98d1355a5e83184751187963f33161d3edda49R20-R21) [[2]](diffhunk://#diff-806b0ecb862b870ebdad1147da98d1355a5e83184751187963f33161d3edda49R62-R71) [[3]](diffhunk://#diff-806b0ecb862b870ebdad1147da98d1355a5e83184751187963f33161d3edda49R90-R103) [[4]](diffhunk://#diff-806b0ecb862b870ebdad1147da98d1355a5e83184751187963f33161d3edda49R121-R129)

**Payload subclass updates:**

* Updated constructors of all payload subclasses (e.g., `DumpPayload`, `JsonPayload`, `TablePayload`, `TableV2Payload`, `BenchmarkPayload`, `ColorPayload`, `LabelPayload`, `ScreenPayload`, `TimeTrackPayload`, `ValidateStringPayload`) to call `setOriginalContent` with the appropriate value, ensuring that original content is captured at instantiation. [[1]](diffhunk://#diff-d8dfb434006f1f912065801b1097837cf31e0dd27cd8bfc078c513d456a872d7R14) [[2]](diffhunk://#diff-9b97c9750c41628df98b8dff852be7e344dbccee1d6b3dd833838e0fa8ec3b42R12) [[3]](diffhunk://#diff-5db2c3dfb34ac26787c6733c763d3cdf7a2249aa9445398f6d2a45619bef3fe2R14) [[4]](diffhunk://#diff-dce15795ba8cfb807eb5823b212563ca5504e461115a9e93a5f20bbf4fccd18aR12) [[5]](diffhunk://#diff-8779a6686a8d4847133890b39cbfe87410b7e82b9ef308f75b6547a76d2dad87R13) [[6]](diffhunk://#diff-644039b1bb28fc0f857c55ef8708a6e4eb9a5712517fd58a834cbdadd9a842b4R12) [[7]](diffhunk://#diff-945439a7f2f6b56355595335fa31530db3bdcf8289f144a012874e232f5540b0R18-R19) [[8]](diffhunk://#diff-c3a62af115bf753f718600b49ec9691bff97d654392dc7b0870a226ccf881489R15) [[9]](diffhunk://#diff-39ce97bbda6028647db549b4614ed4ab90c813acf10b92360c8d4842acbae7a2R15) [[10]](diffhunk://#diff-2bd42b7c500263e73fb08f20a8b20dabc8fa4b519e056cc93a82f5982d712ae6R18)

* Removed redundant or direct assignments of `original_content` in the `content()` methods of payloads, as this is now handled centrally in the base class. [[1]](diffhunk://#diff-5db2c3dfb34ac26787c6733c763d3cdf7a2249aa9445398f6d2a45619bef3fe2L27) [[2]](diffhunk://#diff-dce15795ba8cfb807eb5823b212563ca5504e461115a9e93a5f20bbf4fccd18aL23)

**Testing and validation:**

* Added a comprehensive new test suite (`tests/Feature/OriginalContentTest.php`) to verify that all payloads correctly set, retrieve, and update their `original_content`. The tests cover various data types, edge cases, and dynamic updates after instantiation.

**Code cleanup:**

* Removed an unused import of `ConvertArrayToPhpSyntax` from `DumpPayload.php`, as conversion is now handled in the base class.

These changes make the handling of original content more robust, consistent, and easier to maintain across all payload types.