### PR TITLE
chore: add support for different Symfony versions in CheckCommandTest

### DIFF
--- a/tests/Feature/CheckCommandTest.php
+++ b/tests/Feature/CheckCommandTest.php
@@ -7,7 +7,13 @@ use Symfony\Component\Console\Tester\CommandTester;
 function startCommandApplication(array $arguments): CommandTester
 {
     $application = new Application();
-    $application->add(new CheckCommand());
+
+    // Support for Symfony <8 (add method) and Symfony >=8 (addCommand method)
+    if (method_exists($application, 'add')) {
+        $application->add(new CheckCommand());
+    } else {
+        $application->addCommand(new CheckCommand());
+    }
 
     $command = $application->find('check');
 


### PR DESCRIPTION
This pull request improves compatibility with different versions of Symfony in the `tests/Feature/CheckCommandTest.php` file by updating how commands are registered with the application.

Symfony version compatibility:

* Updated the command registration logic to support both Symfony versions before 8 (using the `add` method) and Symfony 8 or later (using the `addCommand` method).