### PR TITLE
fix: add trailing directory separator in appBasePath()

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -20,7 +20,7 @@ if (!function_exists('appBasePath')) {
             $suffix = DIRECTORY_SEPARATOR . $dir . DIRECTORY_SEPARATOR;
 
             if (str_ends_with($basePath, $suffix)) {
-                return substr($basePath, 0, -strlen($suffix));
+                return substr($basePath, 0, -strlen($suffix)) . DIRECTORY_SEPARATOR;
             }
         }
 


### PR DESCRIPTION
## Summary

`appBasePath()` in `src/functions.php` returns a path **without a trailing directory separator** when stripping known subdirectories (`public/`, `pub/`, `wp-admin/`, `web/`). This causes `Config::init()` to construct an invalid config file path (e.g. `/var/www/htmllaradumps.yaml` instead of `/var/www/html/laradumps.yaml`), silently preventing `ds()` from producing any output.

This only affects **non-Laravel projects** (TYPO3, Symfony, WordPress, etc.) where `getcwd()` is used and the document root is a subdirectory. Laravel is unaffected because `app()->basePath()` is used instead.

## Steps to reproduce

1. Install `laradumps/laradumps-core` in a project where the web server document root is `public/` (or any other known subdirectory)
2. Call `ds('hello')` in a controller executed via a web request
3. Nothing appears in LaraDumps — no errors, no exceptions, completely silent

## Root cause

```php
// src/functions.php line 23
if (str_ends_with($basePath, $suffix)) {
    return substr($basePath, 0, -strlen($suffix));
    //     ^^^^^^ missing trailing DIRECTORY_SEPARATOR
}
```

The default return path on line 27 (`return $basePath;`) correctly includes the trailing separator, but the subdirectory-stripping branch does not.

## Fix

Append `DIRECTORY_SEPARATOR` to the return value to ensure a consistent trailing slash across all code paths:

```diff
- return substr($basePath, 0, -strlen($suffix));
+ return substr($basePath, 0, -strlen($suffix)) . DIRECTORY_SEPARATOR;
```