### PR TITLE
fix: locate laradumps.yaml by walking up the directory tree

### DIFF
--- a/src/Actions/Config.php
+++ b/src/Actions/Config.php
@@ -14,8 +14,47 @@ class Config
     private static function init(): void
     {
         if (!isset(self::$configFilePath)) {
-            self::$configFilePath = appBasePath() . 'laradumps.yaml';
+            self::$configFilePath = self::locateConfigFile();
         }
+    }
+
+    /**
+     * Locate the laradumps.yaml config file by walking up the directory tree
+     * from the current working directory — the same strategy spatie/ray uses
+     * to find ray.php. This keeps config discovery independent of the entry
+     * point, so it also works with CMS that serve requests from a nested
+     * document root (e.g. TYPO3's public/typo3/ backend, where the working
+     * directory is below the project root and stripping a single known suffix
+     * is not enough).
+     *
+     * Falls back to the conventional location next to the document root when
+     * no config file exists yet, e.g. when `laradumps init` first creates it.
+     */
+    private static function locateConfigFile(): string
+    {
+        $directory = getcwd();
+
+        if ($directory !== false) {
+            $directory = rtrim(realpath($directory) ?: $directory, DIRECTORY_SEPARATOR);
+
+            while (@is_dir($directory)) {
+                $candidate = $directory . DIRECTORY_SEPARATOR . 'laradumps.yaml';
+
+                if (file_exists($candidate)) {
+                    return $candidate;
+                }
+
+                $parent = dirname($directory);
+
+                if ($parent === $directory) {
+                    break;
+                }
+
+                $directory = $parent;
+            }
+        }
+
+        return appBasePath() . 'laradumps.yaml';
     }
 
     private static function loadConfig(): array

--- a/tests/Feature/ConfigDiscoveryTest.php
+++ b/tests/Feature/ConfigDiscoveryTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use LaraDumps\LaraDumpsCore\Actions\Config;
+
+describe('Config file discovery', function () {
+    beforeEach(function () {
+        $this->originalCwd = getcwd();
+        $this->root        = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'ld_config_discovery_' . uniqid();
+    });
+
+    afterEach(function () {
+        chdir($this->originalCwd);
+
+        $cleanup = function (string $dir) use (&$cleanup): void {
+            if (!is_dir($dir)) {
+                return;
+            }
+
+            foreach (scandir($dir) as $entry) {
+                if ($entry === '.' || $entry === '..') {
+                    continue;
+                }
+                $path = $dir . DIRECTORY_SEPARATOR . $entry;
+                is_dir($path) ? $cleanup($path) : @unlink($path);
+            }
+            @rmdir($dir);
+        };
+        $cleanup($this->root);
+    });
+
+    $locate = function (): string {
+        // ReflectionMethod kann private Methoden ab PHP 8.1 ohne setAccessible aufrufen
+        return (new ReflectionMethod(Config::class, 'locateConfigFile'))->invoke(null);
+    };
+
+    it('walks up the directory tree to find laradumps.yaml', function () use ($locate) {
+        $nested = $this->root . '/public/typo3';
+        mkdir($nested, 0o777, true);
+        file_put_contents($this->root . '/laradumps.yaml', "app:\n  port: 9191\n");
+
+        // Simuliert einen verschachtelten Einstiegspunkt (z.B. TYPO3-Backend)
+        chdir($nested);
+
+        expect($locate())->toBe(
+            realpath($this->root) . DIRECTORY_SEPARATOR . 'laradumps.yaml'
+        );
+    });
+
+    it('falls back to the document root location when no config exists', function () use ($locate) {
+        $public = $this->root . '/public';
+        mkdir($public, 0o777, true);
+
+        chdir($public);
+
+        // Keine laradumps.yaml im Baum -> Fallback via appBasePath (public/ wird abgeschnitten)
+        expect($locate())->toBe(
+            realpath($this->root) . DIRECTORY_SEPARATOR . 'laradumps.yaml'
+        );
+    });
+});


### PR DESCRIPTION
## Problem

Config discovery resolves the path as `appBasePath() . 'laradumps.yaml'`. `appBasePath()` derives the base from `getcwd()` and only strips a **single** known document-root suffix (`public/`, `pub/`, `wp-admin/`, `web/`).

This breaks for CMS that serve requests from a **nested** document root. The case I hit is **TYPO3**: its backend runs through `public/typo3/index.php`, so during a backend request `getcwd()` is `…/public/typo3`. Stripping a single suffix yields `…/public/typo3/` (it does not end in `public/`), so `laradumps.yaml` at the project root is never found. `secondary_host` resolves to `null`, `primary_host` falls back to the default, and **dumps are silently dropped** — only in the backend. Frontend (`public/`) and CLI (project root) work fine, which makes this confusing to diagnose.

## Fix

Locate the config file the same way `spatie/ray` locates `ray.php`: **walk up the directory tree** from the current working directory until `laradumps.yaml` is found. This makes config discovery independent of the entry point and works for any nesting depth and any CMS.

When no config file exists anywhere up the tree (e.g. before `laradumps init` creates it), it falls back to the previous `appBasePath()`-based location, so init and existing behaviour are preserved.

`appBasePath()` is intentionally **left untouched** — it is also used to resolve user-supplied relative paths in the `check` command and to trim backtrace frames, so changing it there would alter unrelated behaviour. The fix is scoped to `Config` only.

## Tests

Added `tests/Feature/ConfigDiscoveryTest.php`:
- walks up a nested tree (`<root>/public/typo3`) and finds `<root>/laradumps.yaml`
- falls back to the document-root location when no config exists

Full suite green, `pint --test` clean, `phpstan` reports no errors.