### PR TITLE
feat: Variable Name Display & Grouped Dumps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "laradumps/laradumps-core",
+    "version": "4.0.7-dev",
     "description": "LaraDumps is a friendly app designed to boost your Laravel / PHP coding and debugging experience.",
     "homepage": "https://github.com/laradumps/laradumps-core",
     "license": "MIT",

--- a/src/Actions/Dumper.php
+++ b/src/Actions/Dumper.php
@@ -8,49 +8,43 @@ use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 
 class Dumper
 {
-    public static function dump(mixed $arguments, ?int $maxDepth = null): array
+    public static function dump(mixed $arguments, ?int $maxDepth = null, bool $forceCloner = false): array
     {
         $id = Uuid::uuid4()->toString();
 
-        if ($arguments === "") {
-            $arguments = "&nbsp; ";
-        }
+        if (!$forceCloner) {
+            if ($arguments === '') {
+                $arguments = '&nbsp; ';
+            }
 
-        if (is_null($arguments)) {
-            return [null, $id];
-        }
+            if (is_null($arguments)) {
+                return [null, $id];
+            }
 
-        if (is_string($arguments)) {
-            return [$arguments, $id];
-        }
+            if (is_string($arguments)) {
+                return [$arguments, $id];
+            }
 
-        if (is_int($arguments)) {
-            return [$arguments, $id];
-        }
+            if (is_int($arguments)) {
+                return [$arguments, $id];
+            }
 
-        if (is_bool($arguments)) {
-            return [$arguments, $id];
+            if (is_bool($arguments)) {
+                return [$arguments, $id];
+            }
         }
 
         $varCloner = new VarCloner();
-
-        $dumper = new HtmlDumper();
+        $dumper    = new HtmlDumper();
 
         if (!empty($maxDepth)) {
-            $dumper->setDisplayOptions([
-                'maxDepth' => $maxDepth,
-            ]);
+            $dumper->setDisplayOptions(['maxDepth' => $maxDepth]);
         }
 
         $htmlDumper = (string) $dumper->dump($varCloner->cloneVar($arguments), true);
+        $pre        = Support::cut($htmlDumper, '<pre ', '</pre>');
+        $id         = Support::between($pre, 'class=sf-dump id=sf-dump-', ' data-indent-pad="  "');
 
-        $pre = Support::cut($htmlDumper, '<pre ', '</pre>');
-
-        $id = Support::between($pre, 'class=sf-dump id=sf-dump-', ' data-indent-pad="  "');
-
-        return [
-            $pre,
-            $id,
-        ];
+        return [$pre, $id];
     }
 }

--- a/src/Actions/VariableParser.php
+++ b/src/Actions/VariableParser.php
@@ -10,7 +10,8 @@ class VariableParser
             return self::fallback($argCount, $callLine);
         }
 
-        $source   = file_get_contents($file);
+        $source = file_get_contents($file);
+
         if ($source === false) {
             return self::fallback($argCount, $callLine);
         }

--- a/src/Actions/VariableParser.php
+++ b/src/Actions/VariableParser.php
@@ -11,6 +11,9 @@ class VariableParser
         }
 
         $source   = file_get_contents($file);
+        if ($source === false) {
+            return self::fallback($argCount, $callLine);
+        }
         $tokens   = token_get_all($source);
         $argNames = self::extractArgNames($tokens, $callLine, $argCount);
 

--- a/src/Actions/VariableParser.php
+++ b/src/Actions/VariableParser.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace LaraDumps\LaraDumpsCore\Actions;
+
+class VariableParser
+{
+    public static function parse(string $file, int $callLine, int $argCount): array
+    {
+        if (!is_file($file) || !is_readable($file)) {
+            return self::fallback($argCount, $callLine);
+        }
+
+        $source   = file_get_contents($file);
+        $tokens   = token_get_all($source);
+        $argNames = self::extractArgNames($tokens, $callLine, $argCount);
+
+        $result = [];
+
+        foreach ($argNames as $i => $name) {
+            $line = $name !== null
+                ? self::findDeclarationLine($tokens, $name, $callLine)
+                : $callLine;
+
+            $result[] = [
+                'name' => $name ?? 'arg' . $i,
+                'line' => $line,
+            ];
+        }
+
+        if (empty($result)) {
+            return self::fallback($argCount, $callLine);
+        }
+
+        return $result;
+    }
+
+    private static function extractArgNames(array $tokens, int $callLine, int $argCount): array
+    {
+        $count       = count($tokens);
+        $dsStart     = null;
+        $currentLine = 1;
+
+        for ($i = 0; $i < $count; $i++) {
+            $token = $tokens[$i];
+
+            if (is_array($token)) {
+                $currentLine = $token[2];
+            }
+
+            if (
+                is_array($token)
+                && $token[0] === T_STRING
+                && in_array($token[1], ['ds', 'dsd', 'dsq'], true)
+                && $currentLine === $callLine
+            ) {
+                $j = $i + 1;
+
+                while ($j < $count && is_array($tokens[$j]) && $tokens[$j][0] === T_WHITESPACE) {
+                    $j++;
+                }
+
+                if (isset($tokens[$j]) && $tokens[$j] === '(') {
+                    $dsStart = $j;
+
+                    break;
+                }
+            }
+        }
+
+        if ($dsStart === null) {
+            return array_fill(0, $argCount, null);
+        }
+
+        return self::extractArgsFromParens($tokens, $dsStart, $argCount);
+    }
+
+    private static function extractArgsFromParens(array $tokens, int $parenOpen, int $argCount): array
+    {
+        $names     = [];
+        $depth     = 0;
+        $count     = count($tokens);
+        $argTokens = [];
+        $i         = $parenOpen;
+
+        while ($i < $count) {
+            $token = $tokens[$i];
+
+            if ($token === '(') {
+                $depth++;
+
+                if ($depth > 1) {
+                    $argTokens[] = $token;
+                }
+
+                $i++;
+
+                continue;
+            }
+
+            if ($token === ')') {
+                $depth--;
+
+                if ($depth === 0) {
+                    $names[] = self::resolveArgName($argTokens);
+
+                    break;
+                }
+
+                $argTokens[] = $token;
+                $i++;
+
+                continue;
+            }
+
+            if ($token === ',' && $depth === 1) {
+                $names[]   = self::resolveArgName($argTokens);
+                $argTokens = [];
+                $i++;
+
+                continue;
+            }
+
+            if (is_array($token) && $token[0] === T_WHITESPACE) {
+                $i++;
+
+                continue;
+            }
+
+            $argTokens[] = $token;
+            $i++;
+        }
+
+        while (count($names) < $argCount) {
+            $names[] = null;
+        }
+
+        return array_slice($names, 0, $argCount);
+    }
+
+    private static function resolveArgName(array $argTokens): ?string
+    {
+        $significant = array_filter($argTokens, fn ($t) => !(is_array($t) && $t[0] === T_WHITESPACE));
+        $significant = array_values($significant);
+
+        if (count($significant) === 1 && is_array($significant[0]) && $significant[0][0] === T_VARIABLE) {
+            return ltrim($significant[0][1], '$');
+        }
+
+        return null;
+    }
+
+    private static function findDeclarationLine(array $tokens, string $varName, int $callLine): int
+    {
+        $varToken = '$' . $varName;
+        $lastLine = $callLine;
+        $count    = count($tokens);
+
+        for ($i = 0; $i < $count; $i++) {
+            $token = $tokens[$i];
+
+            if (!is_array($token)) {
+                continue;
+            }
+
+            if ($token[2] >= $callLine) {
+                break;
+            }
+
+            if ($token[0] !== T_VARIABLE || $token[1] !== $varToken) {
+                continue;
+            }
+
+            $j = $i + 1;
+
+            while ($j < $count && is_array($tokens[$j]) && $tokens[$j][0] === T_WHITESPACE) {
+                $j++;
+            }
+
+            if (isset($tokens[$j]) && $tokens[$j] === '=') {
+                $next = $tokens[$j + 1] ?? null;
+
+                if ($next !== '=') {
+                    $lastLine = $token[2];
+                }
+            }
+        }
+
+        return $lastLine;
+    }
+
+    private static function fallback(int $argCount, int $callLine): array
+    {
+        $result = [];
+
+        for ($i = 0; $i < $argCount; $i++) {
+            $result[] = ['name' => 'arg' . $i, 'line' => $callLine];
+        }
+
+        return $result;
+    }
+}

--- a/src/Commands/laradumps-base.yaml
+++ b/src/Commands/laradumps-base.yaml
@@ -9,6 +9,7 @@ app:
 config:
     sleep: 0
     macos_auto_launch: false
+    grouped_dumps: false
 observers:
     auto_invoke_app: false
     enabled_in_testing: false

--- a/src/LaraDumps.php
+++ b/src/LaraDumps.php
@@ -42,6 +42,8 @@ class LaraDumps
 
     public static ?\Closure $beforeSend = null;
 
+    private ?string $pendingVariableName = null;
+
     public function __construct(
         private string $notificationId = '',
     ) {
@@ -55,8 +57,11 @@ class LaraDumps
         $this->notificationId = Uuid::uuid4()->toString();
     }
 
-    protected function beforeWrite(mixed $args, ?string $variableName = null): \Closure
+    protected function beforeWrite(mixed $args): \Closure
     {
+        $variableName = $this->pendingVariableName;
+        $this->pendingVariableName = null;
+
         return function () use ($args, $variableName) {
             if (is_string($args) && Support::isJson($args)) {
                 return [
@@ -125,7 +130,8 @@ class LaraDumps
 
     public function write(mixed $args = null, ?bool $autoInvokeApp = null, ?string $variableName = null): self
     {
-        [$payload, $id] = $this->beforeWrite($args, $variableName)();
+        $this->pendingVariableName = $variableName;
+        [$payload, $id] = $this->beforeWrite($args)();
 
         /** @var Payload $payload */
         $payload->autoInvokeApp($autoInvokeApp);

--- a/src/LaraDumps.php
+++ b/src/LaraDumps.php
@@ -59,7 +59,7 @@ class LaraDumps
 
     protected function beforeWrite(mixed $args): \Closure
     {
-        $variableName = $this->pendingVariableName;
+        $variableName              = $this->pendingVariableName;
         $this->pendingVariableName = null;
 
         return function () use ($args, $variableName) {
@@ -131,7 +131,7 @@ class LaraDumps
     public function write(mixed $args = null, ?bool $autoInvokeApp = null, ?string $variableName = null): self
     {
         $this->pendingVariableName = $variableName;
-        [$payload, $id] = $this->beforeWrite($args)();
+        [$payload, $id]            = $this->beforeWrite($args)();
 
         /** @var Payload $payload */
         $payload->autoInvokeApp($autoInvokeApp);

--- a/src/LaraDumps.php
+++ b/src/LaraDumps.php
@@ -127,10 +127,6 @@ class LaraDumps
     {
         [$payload, $id] = $this->beforeWrite($args, $variableName)();
 
-        if (empty($payload) && is_null($id)) {
-            return $this;
-        }
-
         /** @var Payload $payload */
         $payload->autoInvokeApp($autoInvokeApp);
         $payload->setDumpId($id);
@@ -208,6 +204,8 @@ class LaraDumps
 
     /**
      * Send dump and die
+     *
+     * @codeCoverageIgnore
      */
     public function die(string $status = ''): void
     {
@@ -352,7 +350,7 @@ class LaraDumps
     public static function macosAutoLaunch(): void
     {
         if (PHP_OS_FAMILY != 'Darwin') {
-            return;
+            return; // @codeCoverageIgnore
         }
 
         if (!Config::get('config.macos_auto_launch', false)) {

--- a/src/LaraDumps.php
+++ b/src/LaraDumps.php
@@ -3,7 +3,7 @@
 namespace LaraDumps\LaraDumpsCore;
 
 use Closure;
-use LaraDumps\LaraDumpsCore\Actions\{Config, Dumper, Support};
+use LaraDumps\LaraDumpsCore\Actions\{Config, ConvertArrayToPhpSyntax, Dumper, Support, VariableParser};
 use LaraDumps\LaraDumpsCore\Concerns\Colors;
 use LaraDumps\LaraDumpsCore\Dispatcher\Dispatcher;
 use LaraDumps\LaraDumpsCore\Payloads\{
@@ -11,6 +11,7 @@ use LaraDumps\LaraDumpsCore\Payloads\{
     ClearPayload,
     ColorPayload,
     DumpPayload,
+    GroupedDumpPayload,
     JsonPayload,
     LabelPayload,
     Payload,
@@ -54,9 +55,9 @@ class LaraDumps
         $this->notificationId = Uuid::uuid4()->toString();
     }
 
-    protected function beforeWrite(mixed $args): \Closure
+    protected function beforeWrite(mixed $args, ?string $variableName = null): \Closure
     {
-        return function () use ($args) {
+        return function () use ($args, $variableName) {
             if (is_string($args) && Support::isJson($args)) {
                 return [
                     new JsonPayload($args),
@@ -67,7 +68,7 @@ class LaraDumps
             [$pre, $id] = Dumper::dump($args);
 
             return [
-                new DumpPayload($pre, $args, variableType: gettype($args)),
+                new DumpPayload($pre, $args, variableType: gettype($args), variableName: $variableName),
                 $id,
             ];
         };
@@ -98,9 +99,33 @@ class LaraDumps
         return $payload;
     }
 
-    public function write(mixed $args = null, ?bool $autoInvokeApp = null): self
+    public function writeGrouped(array $args, string $file, int $line): self
     {
-        [$payload, $id] = $this->beforeWrite($args)();
+        $varInfos = VariableParser::parse($file, $line, count($args));
+        $items    = [];
+
+        foreach ($args as $i => $arg) {
+            [$dumpHtml, $sfDumpId] = Dumper::dump($arg, forceCloner: true);
+
+            $items[] = [
+                'name'             => $varInfos[$i]['name'] ?? 'arg' . $i,
+                'line'             => $varInfos[$i]['line'] ?? $line,
+                'sf_dump_id'       => $sfDumpId,
+                'dump'             => $dumpHtml,
+                'original_content' => ConvertArrayToPhpSyntax::convert($arg),
+                'variable_type'    => gettype($arg),
+            ];
+        }
+
+        $payload = new GroupedDumpPayload($items);
+        $this->send($payload);
+
+        return $this;
+    }
+
+    public function write(mixed $args = null, ?bool $autoInvokeApp = null, ?string $variableName = null): self
+    {
+        [$payload, $id] = $this->beforeWrite($args, $variableName)();
 
         if (empty($payload) && is_null($id)) {
             return $this;

--- a/src/Payloads/DumpPayload.php
+++ b/src/Payloads/DumpPayload.php
@@ -12,6 +12,7 @@ class DumpPayload extends Payload
         public ?string $variableType = null,
         private string $screen = 'home',
         private string $label = '',
+        public ?string $variableName = null,
     ) {
     }
 
@@ -26,6 +27,7 @@ class DumpPayload extends Payload
             'dump'             => $this->dump,
             'original_content' => ConvertArrayToPhpSyntax::convert($this->originalContent),
             'variable_type'    => $this->variableType,
+            'variable_name'    => $this->variableName,
         ];
     }
 

--- a/src/Payloads/GroupedDumpPayload.php
+++ b/src/Payloads/GroupedDumpPayload.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace LaraDumps\LaraDumpsCore\Payloads;
+
+class GroupedDumpPayload extends Payload
+{
+    public function __construct(private readonly array $items)
+    {
+    }
+
+    public function type(): string
+    {
+        return 'dump_group';
+    }
+
+    public function content(): array
+    {
+        return ['items' => $this->items];
+    }
+
+    public function toScreen(): array|Screen
+    {
+        return new Screen('home');
+    }
+
+    public function withLabel(): array|Label
+    {
+        return new Label('');
+    }
+}

--- a/src/Payloads/Payload.php
+++ b/src/Payloads/Payload.php
@@ -120,10 +120,6 @@ abstract class Payload
 
     private function getConvertedOriginalContent(): mixed
     {
-        if ($this->originalContent === null) {
-            return null;
-        }
-
         return \LaraDumps\LaraDumpsCore\Actions\ConvertArrayToPhpSyntax::convert($this->originalContent);
     }
 
@@ -133,6 +129,7 @@ abstract class Payload
             return [];
         }
 
+        // @codeCoverageIgnoreStart
         if (!class_exists(\Illuminate\Support\Facades\Context::class)) {
             return [];
         }
@@ -149,5 +146,6 @@ abstract class Payload
         return [
             'context' => \Illuminate\Support\Facades\Context::all(),
         ];
+        // @codeCoverageIgnoreEnd
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,6 +1,7 @@
 <?php
 
 use LaraDumps\LaraDumps\LaraDumps as LaravelLaraDumps;
+use LaraDumps\LaraDumpsCore\Actions\{Config, VariableParser};
 use LaraDumps\LaraDumpsCore\LaraDumps;
 
 if (!function_exists('appBasePath')) {
@@ -31,11 +32,24 @@ if (!function_exists('appBasePath')) {
 if (!function_exists('ds')) {
     function ds(mixed ...$args): LaraDumps|LaravelLaraDumps
     {
-        $sendRequest = function ($args, LaraDumps $instance) {
-            if ($args) {
-                foreach ($args as $arg) {
-                    $instance->write($arg);
-                }
+        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1)[0];
+
+        $sendRequest = function ($args, LaraDumps $instance) use ($trace) {
+            if (!$args) {
+                return;
+            }
+
+            if (Config::get('config.grouped_dumps', false) && count($args) > 1) {
+                $instance->writeGrouped($args, $trace['file'], $trace['line']);
+
+                return;
+            }
+
+            $varInfos = VariableParser::parse($trace['file'], $trace['line'], count($args));
+
+            foreach ($args as $i => $arg) {
+                $varName = $varInfos[$i]['name'] ?? null;
+                $instance->write($arg, variableName: $varName);
             }
         };
 
@@ -65,10 +79,17 @@ if (!function_exists('phpinfo')) {
 if (!function_exists('dsd')) {
     function dsd(mixed ...$args): void
     {
+        $trace    = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1)[0];
         $instance = new LaraDumps();
 
-        foreach ($args as $arg) {
-            $instance->write($arg);
+        if (Config::get('config.grouped_dumps', false) && count($args) > 1) {
+            $instance->writeGrouped($args, $trace['file'], $trace['line']);
+        } else {
+            $varInfos = VariableParser::parse($trace['file'], $trace['line'], count($args));
+
+            foreach ($args as $i => $arg) {
+                $instance->write($arg, variableName: $varInfos[$i]['name'] ?? null);
+            }
         }
 
         die();
@@ -78,12 +99,23 @@ if (!function_exists('dsd')) {
 if (!function_exists('dsq')) {
     function dsq(mixed ...$args): void
     {
+        $trace    = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1)[0];
         $instance = new LaraDumps();
 
-        if ($args) {
-            foreach ($args as $arg) {
-                $instance->write($arg, autoInvokeApp: false);
-            }
+        if (!$args) {
+            return;
+        }
+
+        if (Config::get('config.grouped_dumps', false) && count($args) > 1) {
+            $instance->writeGrouped($args, $trace['file'], $trace['line']);
+
+            return;
+        }
+
+        $varInfos = VariableParser::parse($trace['file'], $trace['line'], count($args));
+
+        foreach ($args as $i => $arg) {
+            $instance->write($arg, autoInvokeApp: false, variableName: $varInfos[$i]['name'] ?? null);
         }
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -33,8 +33,8 @@ if (!function_exists('ds')) {
     function ds(mixed ...$args): LaraDumps|LaravelLaraDumps
     {
         $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1)[0];
-        $file = $trace['file'] ?? 'unknown';
-        $line = $trace['line'] ?? 0;
+        $file  = $trace['file'] ?? 'unknown';
+        $line  = $trace['line'] ?? 0;
 
         $sendRequest = function ($args, LaraDumps $instance) use ($file, $line) {
             if (!$args) {
@@ -87,8 +87,8 @@ if (!function_exists('dsd')) {
     function dsd(mixed ...$args): void
     {
         $trace    = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1)[0];
-        $file = $trace['file'] ?? 'unknown';
-        $line = $trace['line'] ?? 0;
+        $file     = $trace['file'] ?? 'unknown';
+        $line     = $trace['line'] ?? 0;
         $instance = new LaraDumps();
 
         if (Config::get('config.grouped_dumps', false) && count($args) > 1) {
@@ -109,8 +109,8 @@ if (!function_exists('dsq')) {
     function dsq(mixed ...$args): void
     {
         $trace    = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1)[0];
-        $file = $trace['file'] ?? 'unknown';
-        $line = $trace['line'] ?? 0;
+        $file     = $trace['file'] ?? 'unknown';
+        $line     = $trace['line'] ?? 0;
         $instance = new LaraDumps();
 
         if (!$args) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -8,7 +8,7 @@ if (!function_exists('appBasePath')) {
     function appBasePath(): string
     {
         $pwd = (defined('LARAVEL_START') || isset($_SERVER['LARAVEL_OCTANE'])) && function_exists('app')
-            ? app()->basePath()
+            ? app()->basePath() // @codeCoverageIgnore
             : (getcwd() ?: '');
 
         if ($pwd === '') {
@@ -54,11 +54,13 @@ if (!function_exists('ds')) {
         };
 
         if (class_exists(LaravelLaraDumps::class) && function_exists('app')) {
+            // @codeCoverageIgnoreStart
             $instance = app(LaravelLaraDumps::class);
 
             $sendRequest($args, $instance);
 
             return $instance;
+            // @codeCoverageIgnoreEnd
         }
 
         $instance = new LaraDumps();
@@ -77,6 +79,9 @@ if (!function_exists('phpinfo')) {
 }
 
 if (!function_exists('dsd')) {
+    /**
+     * @codeCoverageIgnore
+     */
     function dsd(mixed ...$args): void
     {
         $trace    = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1)[0];
@@ -124,7 +129,7 @@ if (!function_exists('runningInTest')) {
     function runningInTest(): bool
     {
         if (PHP_SAPI != 'cli') {
-            return false;
+            return false; // @codeCoverageIgnore
         }
 
         if (str_contains($_SERVER['argv'][0], 'phpunit')) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -33,19 +33,21 @@ if (!function_exists('ds')) {
     function ds(mixed ...$args): LaraDumps|LaravelLaraDumps
     {
         $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1)[0];
+        $file = $trace['file'] ?? 'unknown';
+        $line = $trace['line'] ?? 0;
 
-        $sendRequest = function ($args, LaraDumps $instance) use ($trace) {
+        $sendRequest = function ($args, LaraDumps $instance) use ($file, $line) {
             if (!$args) {
                 return;
             }
 
             if (Config::get('config.grouped_dumps', false) && count($args) > 1) {
-                $instance->writeGrouped($args, $trace['file'], $trace['line']);
+                $instance->writeGrouped($args, $file, $line);
 
                 return;
             }
 
-            $varInfos = VariableParser::parse($trace['file'], $trace['line'], count($args));
+            $varInfos = VariableParser::parse($file, $line, count($args));
 
             foreach ($args as $i => $arg) {
                 $varName = $varInfos[$i]['name'] ?? null;
@@ -85,12 +87,14 @@ if (!function_exists('dsd')) {
     function dsd(mixed ...$args): void
     {
         $trace    = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1)[0];
+        $file = $trace['file'] ?? 'unknown';
+        $line = $trace['line'] ?? 0;
         $instance = new LaraDumps();
 
         if (Config::get('config.grouped_dumps', false) && count($args) > 1) {
-            $instance->writeGrouped($args, $trace['file'], $trace['line']);
+            $instance->writeGrouped($args, $file, $line);
         } else {
-            $varInfos = VariableParser::parse($trace['file'], $trace['line'], count($args));
+            $varInfos = VariableParser::parse($file, $line, count($args));
 
             foreach ($args as $i => $arg) {
                 $instance->write($arg, variableName: $varInfos[$i]['name'] ?? null);
@@ -105,6 +109,8 @@ if (!function_exists('dsq')) {
     function dsq(mixed ...$args): void
     {
         $trace    = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1)[0];
+        $file = $trace['file'] ?? 'unknown';
+        $line = $trace['line'] ?? 0;
         $instance = new LaraDumps();
 
         if (!$args) {
@@ -112,12 +118,12 @@ if (!function_exists('dsq')) {
         }
 
         if (Config::get('config.grouped_dumps', false) && count($args) > 1) {
-            $instance->writeGrouped($args, $trace['file'], $trace['line']);
+            $instance->writeGrouped($args, $file, $line);
 
             return;
         }
 
-        $varInfos = VariableParser::parse($trace['file'], $trace['line'], count($args));
+        $varInfos = VariableParser::parse($file, $line, count($args));
 
         foreach ($args as $i => $arg) {
             $instance->write($arg, autoInvokeApp: false, variableName: $varInfos[$i]['name'] ?? null);

--- a/tests/Feature/Actions/DumperTest.php
+++ b/tests/Feature/Actions/DumperTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use LaraDumps\LaraDumpsCore\Actions\Dumper;
+use PHPUnit\Framework\TestCase;
+
+uses(TestCase::class);
+
+describe('Dumper::dump()', function () {
+    it('returns raw string for string input', function () {
+        [$value, $id] = Dumper::dump('hello');
+
+        expect($value)->toBe('hello')
+            ->and($id)->toBeString()->not->toBeEmpty();
+    });
+
+    it('returns raw int for integer input', function () {
+        [$value, $id] = Dumper::dump(42);
+
+        expect($value)->toBe(42);
+    });
+
+    it('returns raw bool for boolean input', function () {
+        [$value] = Dumper::dump(true);
+        expect($value)->toBeTrue();
+
+        [$value] = Dumper::dump(false);
+        expect($value)->toBeFalse();
+    });
+
+    it('returns null for null input', function () {
+        [$value] = Dumper::dump(null);
+        expect($value)->toBeNull();
+    });
+
+    it('returns sf-dump HTML for arrays', function () {
+        [$html, $id] = Dumper::dump(['key' => 'value']);
+
+        expect($html)->toContain('sf-dump')
+            ->and($html)->toContain('sf-dump-key')
+            ->and($id)->toBeString()->not->toBeEmpty();
+    });
+
+    it('returns sf-dump HTML for objects', function () {
+        $obj = (object) ['id' => 1];
+
+        [$html, $id] = Dumper::dump($obj);
+
+        expect($html)->toContain('sf-dump')
+            ->and($id)->toBeString()->not->toBeEmpty();
+    });
+});
+
+describe('Dumper::dump() with forceCloner', function () {
+    it('returns sf-dump HTML for string when forceCloner is true', function () {
+        [$html, $id] = Dumper::dump('hello', forceCloner: true);
+
+        expect($html)->toContain('sf-dump')
+            ->and($html)->toContain('hello')
+            ->and($id)->toBeString()->not->toBeEmpty();
+    });
+
+    it('returns sf-dump HTML for integer when forceCloner is true', function () {
+        [$html, $id] = Dumper::dump(42, forceCloner: true);
+
+        expect($html)->toContain('sf-dump')
+            ->and($html)->toContain('42')
+            ->and($id)->toBeString()->not->toBeEmpty();
+    });
+
+    it('returns sf-dump HTML for boolean when forceCloner is true', function () {
+        [$html, $id] = Dumper::dump(true, forceCloner: true);
+
+        expect($html)->toContain('sf-dump')
+            ->and($html)->toContain('true')
+            ->and($id)->toBeString()->not->toBeEmpty();
+    });
+
+    it('returns sf-dump HTML for null when forceCloner is true', function () {
+        [$html, $id] = Dumper::dump(null, forceCloner: true);
+
+        expect($html)->toContain('sf-dump')
+            ->and($id)->toBeString()->not->toBeEmpty();
+    });
+
+    it('sf-dump id matches between html and returned id', function () {
+        [$html, $id] = Dumper::dump(['x' => 1], forceCloner: true);
+
+        expect($html)->toContain("sf-dump-{$id}");
+    });
+
+    it('produces different ids for successive calls', function () {
+        [, $id1] = Dumper::dump('a', forceCloner: true);
+        [, $id2] = Dumper::dump('b', forceCloner: true);
+
+        expect($id1)->not->toBe($id2);
+    });
+});

--- a/tests/Feature/Actions/DumperTest.php
+++ b/tests/Feature/Actions/DumperTest.php
@@ -32,6 +32,13 @@ describe('Dumper::dump()', function () {
         expect($value)->toBeNull();
     });
 
+    it('converts empty string to &nbsp; space', function () {
+        [$value, $id] = Dumper::dump('');
+
+        expect($value)->toBe('&nbsp; ')
+            ->and($id)->toBeString()->not->toBeEmpty();
+    });
+
     it('returns sf-dump HTML for arrays', function () {
         [$html, $id] = Dumper::dump(['key' => 'value']);
 
@@ -93,5 +100,16 @@ describe('Dumper::dump() with forceCloner', function () {
         [, $id2] = Dumper::dump('b', forceCloner: true);
 
         expect($id1)->not->toBe($id2);
+    });
+});
+
+describe('Dumper::dump() with maxDepth', function () {
+    it('respects maxDepth setting', function () {
+        $nested = ['level1' => ['level2' => ['level3' => 'deep']]];
+
+        [$html, $id] = Dumper::dump($nested, maxDepth: 1);
+
+        expect($html)->toContain('sf-dump')
+            ->and($id)->toBeString()->not->toBeEmpty();
     });
 });

--- a/tests/Feature/Actions/VariableParserTest.php
+++ b/tests/Feature/Actions/VariableParserTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use LaraDumps\LaraDumpsCore\Actions\VariableParser;
+use PHPUnit\Framework\TestCase;
+
+uses(TestCase::class);
+
+// Fixture file used across tests — written once, kept as a known reference.
+$fixtureFile = __DIR__ . '/../../Fixtures/variable-parser-fixture.php';
+
+beforeAll(function () use ($fixtureFile) {
+    file_put_contents($fixtureFile, <<<'PHP'
+<?php
+$name     = 'Luan';
+$lastName = 'Freitas';
+$age      = 35;
+$address  = ['street' => 'Rua das Flores'];
+$user     = (object) ['id' => 1];
+ds($name, $lastName, $age, $address, $user);
+PHP);
+});
+
+afterAll(function () use ($fixtureFile) {
+    @unlink($fixtureFile);
+});
+
+describe('VariableParser::parse()', function () use ($fixtureFile) {
+    it('extracts all variable names from a ds() call', function () use ($fixtureFile) {
+        $result = VariableParser::parse($fixtureFile, 7, 5);
+
+        expect($result)->toHaveCount(5)
+            ->and($result[0]['name'])->toBe('name')
+            ->and($result[1]['name'])->toBe('lastName')
+            ->and($result[2]['name'])->toBe('age')
+            ->and($result[3]['name'])->toBe('address')
+            ->and($result[4]['name'])->toBe('user');
+    });
+
+    it('extracts correct declaration lines for each variable', function () use ($fixtureFile) {
+        $result = VariableParser::parse($fixtureFile, 7, 5);
+
+        expect($result[0]['line'])->toBe(2) // $name
+            ->and($result[1]['line'])->toBe(3) // $lastName
+            ->and($result[2]['line'])->toBe(4) // $age
+            ->and($result[3]['line'])->toBe(5) // $address
+            ->and($result[4]['line'])->toBe(6); // $user
+    });
+
+    it('returns a single variable name for single-arg call', function () use ($fixtureFile) {
+        $result = VariableParser::parse($fixtureFile, 7, 1);
+
+        expect($result)->toHaveCount(1)
+            ->and($result[0]['name'])->toBe('name');
+    });
+
+    it('returns empty array for zero args', function () use ($fixtureFile) {
+        $result = VariableParser::parse($fixtureFile, 7, 0);
+
+        expect($result)->toBeEmpty();
+    });
+
+    it('returns fallback name for non-variable arguments', function () {
+        $tempFile = sys_get_temp_dir() . '/vp_literal_test.php';
+        file_put_contents($tempFile, "<?php\nds('literal', 42, true);\n");
+
+        $result = VariableParser::parse($tempFile, 2, 3);
+
+        expect($result[0]['name'])->toStartWith('arg')
+            ->and($result[1]['name'])->toStartWith('arg')
+            ->and($result[2]['name'])->toStartWith('arg');
+
+        @unlink($tempFile);
+    });
+
+    it('handles non-existent file gracefully', function () {
+        $result = VariableParser::parse('/non/existent/file.php', 1, 2);
+
+        expect($result)->toBeArray();
+    });
+});

--- a/tests/Feature/BenchmarkPayloadTest.php
+++ b/tests/Feature/BenchmarkPayloadTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use LaraDumps\LaraDumpsCore\LaraDumps;
+use LaraDumps\LaraDumpsCore\Payloads\BenchmarkPayload;
+use PHPUnit\Framework\TestCase;
+
+uses(TestCase::class);
+
+describe('BenchmarkPayload', function () {
+    it('has type table_v2', function () {
+        $payload = new BenchmarkPayload([fn () => 1 + 1]);
+        expect($payload->type())->toBe('table_v2');
+    });
+
+    it('withLabel returns Benchmark by default', function () {
+        $payload = new BenchmarkPayload([fn () => 1]);
+        expect($payload->withLabel()->label)->toBe('Benchmark');
+    });
+
+    it('toScreen returns home by default', function () {
+        $payload = new BenchmarkPayload([fn () => 1]);
+        expect($payload->toScreen()->screen_name)->toBe('home');
+    });
+
+    it('content returns values key', function () {
+        $payload = new BenchmarkPayload([fn () => 42]);
+        $content = $payload->content();
+        expect($content)->toHaveKey('values');
+    });
+
+    it('content includes Fastest key in values', function () {
+        $payload = new BenchmarkPayload([fn () => 'a', fn () => 'b']);
+        $content = $payload->content();
+        expect($content['values'])->toHaveKey('Fastest');
+    });
+
+    it('measures multiple named closures', function () {
+        $payload = new BenchmarkPayload([
+            'alpha' => fn () => str_repeat('x', 100),
+            'beta'  => fn () => implode('', array_fill(0, 100, 'x')),
+        ]);
+        $content = $payload->content();
+        expect($content['values'])->toHaveKey('alpha')
+            ->and($content['values'])->toHaveKey('beta');
+    });
+
+    it('unwraps single-array argument', function () {
+        $closures = [
+            'first'  => fn () => 1,
+            'second' => fn () => 2,
+        ];
+        $payload = new BenchmarkPayload([$closures]);
+        $content = $payload->content();
+        expect($content['values'])->toHaveKey('first')
+            ->and($content['values'])->toHaveKey('second');
+    });
+});
+
+describe('LaraDumps::benchmark()', function () {
+    it('sends a BenchmarkPayload', function () {
+        $captured = null;
+        LaraDumps::beforeSend(function ($payload) use (&$captured) {
+            $captured = $payload;
+        });
+
+        (new LaraDumps())->benchmark(fn () => 1 + 1);
+
+        LaraDumps::beforeSend(null);
+
+        expect($captured)->toBeInstanceOf(BenchmarkPayload::class);
+    });
+});

--- a/tests/Feature/ConfigTest.php
+++ b/tests/Feature/ConfigTest.php
@@ -1,0 +1,193 @@
+<?php
+
+use LaraDumps\LaraDumpsCore\Actions\Config;
+use PHPUnit\Framework\TestCase;
+
+uses(TestCase::class);
+
+// Helpers to create/remove a temp config file and redirect Config to it
+function withTempConfig(array $content, callable $fn): void
+{
+    $dir = sys_get_temp_dir() . '/laradumps_config_test_' . uniqid();
+    mkdir($dir);
+    $file = $dir . '/laradumps.yaml';
+
+    file_put_contents($file, \Symfony\Component\Yaml\Yaml::dump($content));
+
+    // Patch configFilePath via reflection
+    $ref  = new ReflectionClass(Config::class);
+    $path = $ref->getProperty('configFilePath');
+    $path->setAccessible(true);
+    $cache = $ref->getProperty('cachedContent');
+    $cache->setAccessible(true);
+
+    $originalPath  = $path->isInitialized() ? $path->getValue(null) : null;
+    $originalCache = $cache->getValue(null);
+
+    $path->setValue(null, $file);
+    $cache->setValue(null, null);
+
+    try {
+        $fn($file, $dir);
+    } finally {
+        // Restore
+        if ($originalPath !== null) {
+            $path->setValue(null, $originalPath);
+        }
+        $cache->setValue(null, $originalCache);
+        @unlink($file);
+        @rmdir($dir);
+    }
+}
+
+describe('Config::get()', function () {
+    it('returns default when key does not exist', function () {
+        withTempConfig(['observers' => ['enabled_in_testing' => true], 'app' => ['port' => 9191]], function () {
+            expect(Config::get('config.missing', 'default_val'))->toBe('default_val');
+        });
+    });
+
+    it('returns nested value by dot notation', function () {
+        withTempConfig([
+            'observers' => ['enabled_in_testing' => true],
+            'config'    => ['sleep' => 5],
+        ], function () {
+            expect(Config::get('config.sleep', 0))->toBe(5);
+        });
+    });
+
+    it('returns false in test context when enabled_in_testing is false', function () {
+        withTempConfig([
+            'observers' => ['enabled_in_testing' => false],
+            'config'    => ['sleep' => 5],
+        ], function () {
+            // runningInTest() returns true in phpunit context
+            expect(Config::get('config.sleep', 0))->toBeFalse();
+        });
+    });
+});
+
+describe('Config::exists()', function () {
+    it('returns true when config file exists', function () {
+        withTempConfig(['observers' => ['enabled_in_testing' => true], 'app' => []], function () {
+            expect(Config::exists())->toBeTrue();
+        });
+    });
+
+    it('returns false when config file does not exist', function () {
+        $ref   = new ReflectionClass(Config::class);
+        $path  = $ref->getProperty('configFilePath');
+        $cache = $ref->getProperty('cachedContent');
+        $path->setAccessible(true);
+        $cache->setAccessible(true);
+
+        $orig      = $path->isInitialized() ? $path->getValue(null) : null;
+        $origCache = $cache->getValue(null);
+
+        $path->setValue(null, '/non/existent/path/laradumps.yaml');
+        $cache->setValue(null, null);
+
+        $result = Config::exists();
+
+        if ($orig !== null) {
+            $path->setValue(null, $orig);
+        }
+        $cache->setValue(null, $origCache);
+
+        expect($result)->toBeFalse();
+    });
+});
+
+describe('Config::set()', function () {
+    it('sets and persists a nested value', function () {
+        withTempConfig([
+            'observers' => ['enabled_in_testing' => true],
+            'config'    => ['sleep' => 0],
+        ], function () {
+            Config::set('config.sleep', 3);
+            expect(Config::get('config.sleep'))->toBe(3);
+        });
+    });
+
+    it('creates intermediate keys when they do not exist', function () {
+        withTempConfig([
+            'observers' => ['enabled_in_testing' => true],
+        ], function () {
+            Config::set('new_section.new_key', 'value');
+            expect(Config::get('new_section.new_key'))->toBe('value');
+        });
+    });
+});
+
+describe('Config::publish()', function () {
+    it('returns true and writes project_path on success', function () {
+        $srcFile = sys_get_temp_dir() . '/ld_publish_src_' . uniqid() . '.yaml';
+        file_put_contents($srcFile, \Symfony\Component\Yaml\Yaml::dump([
+            'observers' => ['enabled_in_testing' => true],
+            'app'       => ['port' => 9191],
+        ]));
+
+        withTempConfig(['observers' => ['enabled_in_testing' => true]], function () use ($srcFile) {
+            $result = Config::publish('/my/project/', $srcFile);
+            expect($result)->toBeTrue();
+            expect(Config::get('app.project_path'))->toBe('/my/project/');
+        });
+
+        @unlink($srcFile);
+    });
+
+    it('returns false when source file does not exist', function () {
+        withTempConfig(['observers' => ['enabled_in_testing' => true]], function () {
+            expect(Config::publish('/pwd/', '/non/existent/file.yaml'))->toBeFalse();
+        });
+    });
+});
+
+describe('Config::loadConfig() with invalid YAML', function () {
+    it('returns empty array when YAML file is malformed (ParseException)', function () {
+        $ref   = new ReflectionClass(Config::class);
+        $path  = $ref->getProperty('configFilePath');
+        $cache = $ref->getProperty('cachedContent');
+        $path->setAccessible(true);
+        $cache->setAccessible(true);
+
+        $orig      = $path->isInitialized() ? $path->getValue(null) : null;
+        $origCache = $cache->getValue(null);
+
+        // Create a file with invalid YAML
+        $dir = sys_get_temp_dir() . '/laradumps_invalid_yaml_' . uniqid();
+        mkdir($dir);
+        $file = $dir . '/laradumps.yaml';
+        file_put_contents($file, "invalid: yaml: [\nbroken");
+
+        $path->setValue(null, $file);
+        $cache->setValue(null, null);
+
+        // This should trigger ParseException, config becomes [].
+        // Since enabled_in_testing defaults to false and runningInTest() is true,
+        // the get() returns false for missing keys in testing context.
+        $result = Config::get('any.key', 'fallback');
+
+        if ($orig !== null) {
+            $path->setValue(null, $orig);
+        }
+        $cache->setValue(null, $origCache);
+
+        @unlink($file);
+        @rmdir($dir);
+
+        // ParseException was caught, config is empty, runningInTest()=true, enabled_in_testing=false => returns false
+        expect($result)->toBeFalse();
+    });
+});
+
+describe('Config::get() with enabled_in_testing false and missing key', function () {
+    it('returns false when key is missing and enabled_in_testing is false', function () {
+        withTempConfig([
+            'observers' => ['enabled_in_testing' => false],
+        ], function () {
+            // Key doesn't exist, runningInTest() is true, enabled_in_testing is false
+            expect(Config::get('nonexistent.key', 'default'))->toBeFalse();
+        });
+    });
+});

--- a/tests/Feature/CurlTest.php
+++ b/tests/Feature/CurlTest.php
@@ -1,0 +1,196 @@
+<?php
+
+use LaraDumps\LaraDumpsCore\Dispatcher\Curl;
+use PHPUnit\Framework\TestCase;
+
+uses(TestCase::class);
+
+beforeEach(function () {
+    // Reset the static $ignorePrimary flag via reflection
+    $ref  = new ReflectionClass(Curl::class);
+    $prop = $ref->getProperty('ignorePrimary');
+    $prop->setAccessible(true);
+    $prop->setValue(null, false);
+});
+
+describe('Curl::make()', function () {
+    it('returns a Curl instance', function () {
+        $curl = Curl::make();
+        expect($curl)->toBeInstanceOf(Curl::class);
+    });
+});
+
+describe('Curl::dispatch()', function () {
+    it('returns false when the URL is not reachable', function () {
+        $curl   = new Curl();
+        $result = $curl->dispatch('http://127.0.0.1:19999/api/dumps', '{"test":true}');
+        expect($result)->toBeFalse();
+    });
+
+    it('returns false when response is not valid JSON with UUID', function () {
+        // We'll test with a URL that will fail/timeout
+        $curl   = new Curl();
+        $result = $curl->dispatch('http://127.0.0.1:19998/api/dumps', '{"test":true}');
+        expect($result)->toBeFalse();
+    });
+});
+
+describe('Curl::handle()', function () {
+    it('returns false when both primary and secondary are unreachable', function () {
+        $curl   = new Curl();
+        $result = $curl->handle(['type' => 'test', 'content' => []]);
+        expect($result)->toBeFalse();
+    });
+
+    it('tries secondary after primary fails', function () {
+        $curl   = new Curl();
+        $result = $curl->handle(['type' => 'test', 'content' => []]);
+        // Both fail, so result is false
+        expect($result)->toBeFalse();
+    });
+
+    it('skips primary when ignorePrimary is true', function () {
+        // Set ignorePrimary to true
+        $ref  = new ReflectionClass(Curl::class);
+        $prop = $ref->getProperty('ignorePrimary');
+        $prop->setAccessible(true);
+        $prop->setValue(null, true);
+
+        $curl   = new Curl();
+        $result = $curl->handle(['type' => 'test', 'content' => []]);
+        // Secondary also fails
+        expect($result)->toBeFalse();
+    });
+});
+
+describe('Curl::dispatch() with mock server', function () {
+    it('returns true when response contains a valid UUID id', function () {
+        // Start a simple PHP built-in server that returns a valid UUID response
+        $port    = 19876;
+        $docRoot = sys_get_temp_dir() . '/ld_curl_test_' . uniqid();
+        mkdir($docRoot);
+        $uuid = \Ramsey\Uuid\Uuid::uuid4()->toString();
+        file_put_contents($docRoot . '/index.php', "<?php echo json_encode(['id' => '{$uuid}']);");
+
+        $proc = proc_open(
+            "php -S 127.0.0.1:{$port} -t {$docRoot}",
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pipes
+        );
+
+        // Give the server time to start
+        usleep(300000);
+
+        try {
+            $curl   = new Curl();
+            $result = $curl->dispatch("http://127.0.0.1:{$port}/index.php", '{"test":true}');
+            expect($result)->toBeTrue();
+        } finally {
+            proc_terminate($proc);
+            proc_close($proc);
+            @unlink($docRoot . '/index.php');
+            @rmdir($docRoot);
+        }
+    });
+
+    it('returns false when response contains invalid UUID', function () {
+        $port    = 19877;
+        $docRoot = sys_get_temp_dir() . '/ld_curl_test2_' . uniqid();
+        mkdir($docRoot);
+        file_put_contents($docRoot . '/index.php', "<?php echo json_encode(['id' => 'not-a-uuid']);");
+
+        $proc = proc_open(
+            "php -S 127.0.0.1:{$port} -t {$docRoot}",
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pipes
+        );
+
+        usleep(300000);
+
+        try {
+            $curl   = new Curl();
+            $result = $curl->dispatch("http://127.0.0.1:{$port}/index.php", '{"test":true}');
+            expect($result)->toBeFalse();
+        } finally {
+            proc_terminate($proc);
+            proc_close($proc);
+            @unlink($docRoot . '/index.php');
+            @rmdir($docRoot);
+        }
+    });
+
+    it('sets ignorePrimary when primary fails but secondary succeeds', function () {
+        $port    = 19878;
+        $docRoot = sys_get_temp_dir() . '/ld_curl_test3_' . uniqid();
+        mkdir($docRoot);
+        $uuid = \Ramsey\Uuid\Uuid::uuid4()->toString();
+        file_put_contents($docRoot . '/index.php', "<?php echo json_encode(['id' => '{$uuid}']);");
+
+        $proc = proc_open(
+            "php -S 127.0.0.1:{$port} -t {$docRoot}",
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pipes
+        );
+
+        usleep(300000);
+
+        try {
+            // Create a Curl with secondary pointing to our mock server
+            $curl = new Curl();
+
+            // Set secondary URL via reflection to our working server
+            $ref     = new ReflectionClass(Curl::class);
+            $secProp = $ref->getProperty('secondaryUrl');
+            $secProp->setAccessible(true);
+            $secProp->setValue($curl, "http://127.0.0.1:{$port}/index.php");
+
+            // Primary will fail (default 127.0.0.1:9191), secondary should succeed
+            $result = $curl->handle(['type' => 'test', 'content' => []]);
+            expect($result)->toBeTrue();
+
+            // Check that ignorePrimary is now true
+            $ignoreProp = $ref->getProperty('ignorePrimary');
+            $ignoreProp->setAccessible(true);
+            expect($ignoreProp->getValue(null))->toBeTrue();
+        } finally {
+            proc_terminate($proc);
+            proc_close($proc);
+            @unlink($docRoot . '/index.php');
+            @rmdir($docRoot);
+        }
+    });
+
+    it('returns true immediately when primary succeeds', function () {
+        $port    = 19879;
+        $docRoot = sys_get_temp_dir() . '/ld_curl_test4_' . uniqid();
+        mkdir($docRoot);
+        $uuid = \Ramsey\Uuid\Uuid::uuid4()->toString();
+        file_put_contents($docRoot . '/index.php', "<?php echo json_encode(['id' => '{$uuid}']);");
+
+        $proc = proc_open(
+            "php -S 127.0.0.1:{$port} -t {$docRoot}",
+            [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+            $pipes
+        );
+
+        usleep(300000);
+
+        try {
+            $curl = new Curl();
+
+            // Set primary URL to our working server
+            $ref     = new ReflectionClass(Curl::class);
+            $priProp = $ref->getProperty('primaryUrl');
+            $priProp->setAccessible(true);
+            $priProp->setValue($curl, "http://127.0.0.1:{$port}/index.php");
+
+            $result = $curl->handle(['type' => 'test', 'content' => []]);
+            expect($result)->toBeTrue();
+        } finally {
+            proc_terminate($proc);
+            proc_close($proc);
+            @unlink($docRoot . '/index.php');
+            @rmdir($docRoot);
+        }
+    });
+});

--- a/tests/Feature/FunctionsTest.php
+++ b/tests/Feature/FunctionsTest.php
@@ -1,0 +1,311 @@
+<?php
+
+use LaraDumps\LaraDumpsCore\Actions\Config;
+use LaraDumps\LaraDumpsCore\LaraDumps;
+use LaraDumps\LaraDumpsCore\Payloads\{DumpPayload, GroupedDumpPayload, JsonPayload};
+use PHPUnit\Framework\TestCase;
+
+uses(TestCase::class);
+
+// Helper: capture the payload sent
+function captureFnPayload(callable $fn): mixed
+{
+    $captured = null;
+    LaraDumps::beforeSend(function ($payload) use (&$captured) {
+        $captured = $payload;
+    });
+    $fn();
+    LaraDumps::beforeSend(null);
+
+    return $captured;
+}
+
+describe('ds() function', function () {
+    it('returns a LaraDumps instance', function () {
+        $result = captureFnPayload(fn () => $instance = ds('hello'));
+        expect($result)->toBeInstanceOf(DumpPayload::class);
+    });
+
+    it('sends DumpPayload for a single arg', function () {
+        $payload = captureFnPayload(fn () => ds('test'));
+        expect($payload)->toBeInstanceOf(DumpPayload::class);
+    });
+
+    it('sends JsonPayload for a valid JSON string', function () {
+        $payload = captureFnPayload(fn () => ds('{"key":"value"}'));
+        expect($payload)->toBeInstanceOf(JsonPayload::class);
+    });
+
+    it('handles multiple arguments', function () {
+        $lastPayload = null;
+        LaraDumps::beforeSend(function ($payload) use (&$lastPayload) {
+            $lastPayload = $payload;
+        });
+        ds('a', 'b');
+        LaraDumps::beforeSend(null);
+
+        expect($lastPayload)->toBeInstanceOf(DumpPayload::class);
+    });
+
+    it('returns LaraDumps instance when called with no args', function () {
+        LaraDumps::beforeSend(null);
+        $result = ds();
+        expect($result)->toBeInstanceOf(LaraDumps::class);
+    });
+
+    it('sends grouped dumps when config.grouped_dumps is true and multiple args', function () {
+        $ref   = new ReflectionClass(Config::class);
+        $cache = $ref->getProperty('cachedContent');
+        $cache->setAccessible(true);
+        $origCache = $cache->getValue(null);
+
+        $cache->setValue(null, [
+            'observers' => ['enabled_in_testing' => true],
+            'config'    => ['grouped_dumps' => true],
+        ]);
+
+        $lastPayload = null;
+        LaraDumps::beforeSend(function ($payload) use (&$lastPayload) {
+            $lastPayload = $payload;
+        });
+        ds('a', 'b', 'c');
+        LaraDumps::beforeSend(null);
+
+        $cache->setValue(null, $origCache);
+
+        expect($lastPayload)->toBeInstanceOf(GroupedDumpPayload::class);
+    });
+});
+
+describe('dsq() function', function () {
+    it('sends dump with autoInvokeApp false', function () {
+        $payload = captureFnPayload(fn () => dsq('quiet test'));
+        expect($payload)->toBeInstanceOf(DumpPayload::class);
+    });
+
+    it('handles multiple args', function () {
+        $lastPayload = null;
+        LaraDumps::beforeSend(function ($payload) use (&$lastPayload) {
+            $lastPayload = $payload;
+        });
+        dsq('a', 'b');
+        LaraDumps::beforeSend(null);
+
+        expect($lastPayload)->toBeInstanceOf(DumpPayload::class);
+    });
+
+    it('returns early when called with no args', function () {
+        $payload = captureFnPayload(fn () => dsq());
+        expect($payload)->toBeNull();
+    });
+
+    it('sends grouped dumps when config.grouped_dumps is true and multiple args', function () {
+        $ref   = new ReflectionClass(Config::class);
+        $cache = $ref->getProperty('cachedContent');
+        $cache->setAccessible(true);
+        $origCache = $cache->getValue(null);
+
+        $cache->setValue(null, [
+            'observers' => ['enabled_in_testing' => true],
+            'config'    => ['grouped_dumps' => true],
+        ]);
+
+        $lastPayload = null;
+        LaraDumps::beforeSend(function ($payload) use (&$lastPayload) {
+            $lastPayload = $payload;
+        });
+        dsq('x', 'y', 'z');
+        LaraDumps::beforeSend(null);
+
+        $cache->setValue(null, $origCache);
+
+        expect($lastPayload)->toBeInstanceOf(GroupedDumpPayload::class);
+    });
+});
+
+describe('dsd() function', function () {
+    it('sends dump and exits (tested via subprocess)', function () {
+        $autoload = realpath(__DIR__ . '/../../vendor/autoload.php');
+        $script   = "<?php\nrequire '{$autoload}';\n\\LaraDumps\\LaraDumpsCore\\LaraDumps::beforeSend(function() {});\ndsd('goodbye');\n";
+
+        $tempFile = sys_get_temp_dir() . '/ld_dsd_test_' . uniqid() . '.php';
+        file_put_contents($tempFile, $script);
+
+        exec("php {$tempFile} 2>&1", $output, $exitCode);
+        @unlink($tempFile);
+
+        // dsd calls die() which means exit code 0
+        expect($exitCode)->toBe(0);
+    });
+
+    it('sends grouped dumps via subprocess when config.grouped_dumps is true', function () {
+        $autoload = realpath(__DIR__ . '/../../vendor/autoload.php');
+        $script   = <<<PHP
+        <?php
+        require '{$autoload}';
+        
+        \$ref = new ReflectionClass(\\LaraDumps\\LaraDumpsCore\\Actions\\Config::class);
+        \$cache = \$ref->getProperty('cachedContent');
+        \$cache->setAccessible(true);
+        \$cache->setValue(null, [
+            'observers' => ['enabled_in_testing' => true],
+            'config' => ['grouped_dumps' => true],
+        ]);
+        
+        \\LaraDumps\\LaraDumpsCore\\LaraDumps::beforeSend(function() {});
+        dsd('a', 'b');
+        PHP;
+
+        $tempFile = sys_get_temp_dir() . '/ld_dsd_grouped_' . uniqid() . '.php';
+        file_put_contents($tempFile, $script);
+
+        exec("php {$tempFile} 2>&1", $output, $exitCode);
+        @unlink($tempFile);
+
+        expect($exitCode)->toBe(0);
+    });
+
+    it('sends single dump for one arg via subprocess', function () {
+        $autoload = realpath(__DIR__ . '/../../vendor/autoload.php');
+        $script   = "<?php\nrequire '{$autoload}';\n\\LaraDumps\\LaraDumpsCore\\LaraDumps::beforeSend(function() {});\ndsd('single');\n";
+
+        $tempFile = sys_get_temp_dir() . '/ld_dsd_single_' . uniqid() . '.php';
+        file_put_contents($tempFile, $script);
+
+        exec("php {$tempFile} 2>&1", $output, $exitCode);
+        @unlink($tempFile);
+
+        expect($exitCode)->toBe(0);
+    });
+});
+
+describe('runningInTest() function', function () {
+    it('returns true when running under pest/phpunit', function () {
+        expect(runningInTest())->toBeTrue();
+    });
+});
+
+describe('appBasePath() function', function () {
+    it('returns a string ending with directory separator', function () {
+        $path = appBasePath();
+        expect($path)->toBeString()
+            ->and(str_ends_with($path, DIRECTORY_SEPARATOR))->toBeTrue();
+    });
+
+    it('strips public directory suffix when cwd ends with /public/', function () {
+        $tempDir = sys_get_temp_dir() . '/ld_basepath_' . uniqid();
+        $pubDir  = $tempDir . '/public';
+        mkdir($pubDir, 0777, true);
+
+        $origDir = getcwd();
+        chdir($pubDir);
+
+        $path = appBasePath();
+
+        chdir($origDir);
+        @rmdir($pubDir);
+        @rmdir($tempDir);
+
+        // Should strip /public/ and return parent
+        expect($path)->not->toEndWith('/public/')
+            ->and($path)->toEndWith(DIRECTORY_SEPARATOR);
+    });
+
+    it('strips web directory suffix when cwd ends with /web/', function () {
+        $tempDir = sys_get_temp_dir() . '/ld_basepath_web_' . uniqid();
+        $webDir  = $tempDir . '/web';
+        mkdir($webDir, 0777, true);
+
+        $origDir = getcwd();
+        chdir($webDir);
+
+        $path = appBasePath();
+
+        chdir($origDir);
+        @rmdir($webDir);
+        @rmdir($tempDir);
+
+        expect($path)->not->toEndWith('/web/')
+            ->and($path)->toEndWith(DIRECTORY_SEPARATOR);
+    });
+
+    it('returns DIRECTORY_SEPARATOR when getcwd returns false', function () {
+        // Create a temp dir, chdir to it, then remove it to make getcwd() return false
+        $tempDir = sys_get_temp_dir() . '/ld_empty_cwd_' . uniqid();
+        mkdir($tempDir);
+
+        $origDir = getcwd();
+        chdir($tempDir);
+        rmdir($tempDir);
+
+        // getcwd() should return false now (directory doesn't exist)
+        $cwdResult = getcwd();
+
+        if ($cwdResult === false) {
+            $path = appBasePath();
+            chdir($origDir);
+            expect($path)->toBe(DIRECTORY_SEPARATOR);
+        } else {
+            // Some OS may still return the path even if dir is deleted
+            chdir($origDir);
+            @mkdir($tempDir);
+            @rmdir($tempDir);
+            expect(true)->toBeTrue(); // Skip gracefully
+        }
+    });
+});
+
+describe('runningInTest() edge cases via subprocess', function () {
+    it('returns false when not in CLI SAPI (simulated via subprocess)', function () {
+        // We can't change PHP_SAPI in-process, verify we're in CLI
+        expect(PHP_SAPI)->toBe('cli');
+        expect(runningInTest())->toBeTrue();
+    });
+
+    it('detects phpunit in argv', function () {
+        // Current test runner has pest in argv
+        expect(str_contains($_SERVER['argv'][0], 'pest') || str_contains($_SERVER['argv'][0], 'phpunit'))->toBeTrue();
+    });
+
+    it('returns false when argv does not contain pest or phpunit', function () {
+        $origArgv           = $_SERVER['argv'];
+        $_SERVER['argv'][0] = '/usr/bin/php';
+
+        // runningInTest is already defined, we need to call it with modified argv
+        // Since PHP_SAPI is still 'cli', it won't return false on line 127
+        // It will check argv[0] for phpunit (false) and pest (false), then return false (line 138)
+        $result = runningInTest();
+
+        $_SERVER['argv'] = $origArgv;
+
+        expect($result)->toBeFalse();
+    });
+
+    it('returns true when argv contains phpunit', function () {
+        $origArgv           = $_SERVER['argv'];
+        $_SERVER['argv'][0] = '/vendor/bin/phpunit';
+
+        $result = runningInTest();
+
+        $_SERVER['argv'] = $origArgv;
+
+        expect($result)->toBeTrue();
+    });
+});
+
+describe('LaraDumps::die() via subprocess', function () {
+    it('exits the process', function () {
+        $autoload = realpath(__DIR__ . '/../../vendor/autoload.php');
+        $script   = "<?php\nrequire '{$autoload}';\n\\LaraDumps\\LaraDumpsCore\\LaraDumps::beforeSend(function() {});\n\$ld = new \\LaraDumps\\LaraDumpsCore\\LaraDumps();\n\$ld->write('test');\n\$ld->die();\necho 'SHOULD_NOT_REACH';\n";
+
+        $tempFile = sys_get_temp_dir() . '/ld_die_test_' . uniqid() . '.php';
+        file_put_contents($tempFile, $script);
+
+        exec("php {$tempFile} 2>&1", $output, $exitCode);
+        @unlink($tempFile);
+
+        // die() exits with code 0 and does not reach the echo
+        expect($exitCode)->toBe(0);
+        expect(implode("\n", $output))->not->toContain('SHOULD_NOT_REACH');
+    });
+});

--- a/tests/Feature/GroupedDumpsTest.php
+++ b/tests/Feature/GroupedDumpsTest.php
@@ -1,0 +1,137 @@
+<?php
+
+use LaraDumps\LaraDumpsCore\Actions\Dumper;
+use LaraDumps\LaraDumpsCore\LaraDumps;
+use LaraDumps\LaraDumpsCore\Payloads\{DumpPayload, GroupedDumpPayload};
+use PHPUnit\Framework\TestCase;
+
+uses(TestCase::class);
+
+describe('DumpPayload with variable_name', function () {
+    it('includes variable_name in content()', function () {
+        [$pre, $id] = Dumper::dump('Luan');
+        $payload    = new DumpPayload($pre, 'Luan', variableType: 'string', variableName: 'name');
+
+        expect($payload->content())
+            ->toHaveKey('variable_name', 'name')
+            ->toHaveKey('variable_type', 'string');
+    });
+
+    it('variable_name is null when not provided', function () {
+        [$pre, $id] = Dumper::dump('Luan');
+        $payload    = new DumpPayload($pre, 'Luan', variableType: 'string');
+
+        expect($payload->content()['variable_name'])->toBeNull();
+    });
+
+    it('is included in toArray() under the dump key', function () {
+        [$pre, $id] = Dumper::dump(['x' => 1]);
+        $payload    = new DumpPayload($pre, ['x' => 1], variableType: 'array', variableName: 'myArray');
+
+        $ld   = new LaraDumps();
+        $sent = $ld->send($payload, withFrame: false)->toArray();
+
+        expect($sent['dump']['variable_name'])->toBe('myArray')
+            ->and($sent['type'])->toBe('dump');
+    });
+});
+
+describe('GroupedDumpPayload', function () {
+    it('has type dump_group', function () {
+        $payload = new GroupedDumpPayload([]);
+        expect($payload->type())->toBe('dump_group');
+    });
+
+    it('content returns items array', function () {
+        $items = [
+            ['name' => 'name', 'line' => 5, 'sf_dump_id' => 'abc', 'dump' => '<pre>', 'original_content' => 'Luan', 'variable_type' => 'string'],
+            ['name' => 'age',  'line' => 6, 'sf_dump_id' => 'def', 'dump' => '<pre>', 'original_content' => '35',   'variable_type' => 'integer'],
+        ];
+
+        $payload = new GroupedDumpPayload($items);
+
+        expect($payload->content()['items'])->toHaveCount(2)
+            ->and($payload->content()['items'][0]['name'])->toBe('name')
+            ->and($payload->content()['items'][1]['name'])->toBe('age');
+    });
+
+    it('is included in toArray() under dump_group key', function () {
+        $items   = [['name' => 'x', 'line' => 1, 'sf_dump_id' => 'id1', 'dump' => '<pre>', 'original_content' => '1', 'variable_type' => 'integer']];
+        $payload = new GroupedDumpPayload($items);
+
+        $ld   = new LaraDumps();
+        $sent = $ld->send($payload, withFrame: false)->toArray();
+
+        expect($sent['type'])->toBe('dump_group')
+            ->and($sent['dump_group']['items'])->toHaveCount(1);
+    });
+});
+
+describe('LaraDumps::writeGrouped()', function () {
+    it('produces a GroupedDumpPayload with correct item count', function () {
+        $captured = null;
+
+        LaraDumps::beforeSend(function ($payload) use (&$captured) {
+            $captured = $payload;
+        });
+
+        $tempFile = sys_get_temp_dir() . '/grouped_test.php';
+        file_put_contents($tempFile, "<?php\n\$a = 1;\n\$b = 2;\nds(\$a, \$b);\n");
+
+        $ld = new LaraDumps();
+        $ld->writeGrouped([1, 2], $tempFile, 4);
+
+        LaraDumps::beforeSend(null);
+        @unlink($tempFile);
+
+        expect($captured)->toBeInstanceOf(GroupedDumpPayload::class);
+
+        $content = $captured->content();
+        expect($content['items'])->toHaveCount(2)
+            ->and($content['items'][0]['name'])->toBe('a')
+            ->and($content['items'][1]['name'])->toBe('b');
+    });
+
+    it('each item has sf-dump HTML even for primitives', function () {
+        $captured = null;
+
+        LaraDumps::beforeSend(function ($payload) use (&$captured) {
+            $captured = $payload;
+        });
+
+        $tempFile = sys_get_temp_dir() . '/grouped_primitives.php';
+        file_put_contents($tempFile, "<?php\n\$str = 'hello';\n\$num = 42;\nds(\$str, \$num);\n");
+
+        $ld = new LaraDumps();
+        $ld->writeGrouped(['hello', 42], $tempFile, 4);
+
+        LaraDumps::beforeSend(null);
+        @unlink($tempFile);
+
+        $items = $captured->content()['items'];
+
+        expect($items[0]['dump'])->toContain('sf-dump')
+            ->and($items[1]['dump'])->toContain('sf-dump');
+    });
+
+    it('each item sf_dump_id matches the id in the dump HTML', function () {
+        $captured = null;
+
+        LaraDumps::beforeSend(function ($payload) use (&$captured) {
+            $captured = $payload;
+        });
+
+        $tempFile = sys_get_temp_dir() . '/grouped_id_check.php';
+        file_put_contents($tempFile, "<?php\n\$x = [1, 2];\nds(\$x);\n");
+
+        $ld = new LaraDumps();
+        $ld->writeGrouped([[1, 2]], $tempFile, 3);
+
+        LaraDumps::beforeSend(null);
+        @unlink($tempFile);
+
+        $item = $captured->content()['items'][0];
+
+        expect($item['dump'])->toContain("sf-dump-{$item['sf_dump_id']}");
+    });
+});

--- a/tests/Feature/LaraDumpsMethodsTest.php
+++ b/tests/Feature/LaraDumpsMethodsTest.php
@@ -1,0 +1,376 @@
+<?php
+
+use LaraDumps\LaraDumpsCore\Actions\Config;
+use LaraDumps\LaraDumpsCore\LaraDumps;
+use LaraDumps\LaraDumpsCore\Payloads\{BenchmarkPayload,
+    ClearPayload,
+    ColorPayload,
+    DumpPayload,
+    GroupedDumpPayload,
+    JsonPayload,
+    LabelPayload,
+    PhpInfoPayload,
+    ScreenPayload,
+    TimeTrackPayload,
+    ValidJsonPayload,
+    ValidateStringPayload};
+use PHPUnit\Framework\TestCase;
+
+uses(TestCase::class);
+function capturePayload(callable $fn): mixed
+{
+    $captured = null;
+    LaraDumps::beforeSend(function ($payload) use (&$captured) {
+        $captured = $payload;
+    });
+    $fn();
+    LaraDumps::beforeSend(null);
+
+    return $captured;
+}
+
+describe('LaraDumps::write()', function () {
+    it('sends a DumpPayload for a string', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->write('hello'));
+        expect($payload)->toBeInstanceOf(DumpPayload::class);
+    });
+
+    it('sends a JsonPayload when the string is valid JSON', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->write('{"key":"value"}'));
+        expect($payload)->toBeInstanceOf(JsonPayload::class);
+    });
+
+    it('sends DumpPayload with variable_name when provided', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->write('Luan', variableName: 'name'));
+
+        expect($payload)->toBeInstanceOf(DumpPayload::class);
+        expect($payload->content()['variable_name'])->toBe('name');
+    });
+
+    it('returns the same LaraDumps instance (fluent)', function () {
+        $ld   = new LaraDumps();
+        $same = capturePayload(fn () => $ld->write('hello'));
+        expect($ld)->toBeInstanceOf(LaraDumps::class);
+    });
+});
+
+describe('LaraDumps::color() and color aliases', function () {
+    it('sends a ColorPayload with the given color', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->color('purple'));
+        expect($payload)->toBeInstanceOf(ColorPayload::class)
+            ->and($payload->content()['color'])->toBe('purple');
+    });
+
+    it('dark() sends color black', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->dark());
+        expect($payload)->toBeInstanceOf(ColorPayload::class)
+            ->and($payload->content()['color'])->toBe('black');
+    });
+
+    it('red() sends color red', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->red());
+        expect($payload)->toBeInstanceOf(ColorPayload::class);
+    });
+
+    it('blue() sends color blue', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->blue());
+        expect($payload)->toBeInstanceOf(ColorPayload::class);
+    });
+
+    it('green() sends color green', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->green());
+        expect($payload)->toBeInstanceOf(ColorPayload::class);
+    });
+
+    it('orange() sends color orange', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->orange());
+        expect($payload)->toBeInstanceOf(ColorPayload::class);
+    });
+});
+
+describe('LaraDumps::label()', function () {
+    it('sends a LabelPayload with the given label', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->label('My Label'));
+        expect($payload)->toBeInstanceOf(LabelPayload::class)
+            ->and($payload->withLabel()->label)->toBe('My Label');
+    });
+});
+
+describe('LaraDumps::toScreen()', function () {
+    it('sends a ScreenPayload with the given name', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->toScreen('errors'));
+        expect($payload)->toBeInstanceOf(ScreenPayload::class)
+            ->and($payload->toScreen()->screen_name)->toBe('errors');
+    });
+
+    it('s() is an alias for toScreen()', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->s('errors'));
+        expect($payload)->toBeInstanceOf(ScreenPayload::class);
+    });
+
+    it('w() sends a new-window ScreenPayload', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->w('popup'));
+        expect($payload)->toBeInstanceOf(ScreenPayload::class)
+            ->and($payload->toScreen()->new_window)->toBeTrue();
+    });
+});
+
+describe('LaraDumps::clear()', function () {
+    it('sends a ClearPayload', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->clear());
+        expect($payload)->toBeInstanceOf(ClearPayload::class);
+    });
+});
+
+describe('LaraDumps::isJson()', function () {
+    it('sends a ValidJsonPayload', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->isJson());
+        expect($payload)->toBeInstanceOf(ValidJsonPayload::class);
+    });
+});
+
+describe('LaraDumps::contains()', function () {
+    it('sends a ValidateStringPayload of type contains', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->contains('hello'));
+        expect($payload)->toBeInstanceOf(ValidateStringPayload::class)
+            ->and($payload->content()['type'])->toBe('contains')
+            ->and($payload->content()['content'])->toBe('hello');
+    });
+
+    it('respects caseSensitive and wholeWord flags', function () {
+        $payload = capturePayload(
+            fn () => (new LaraDumps())->contains('hello', caseSensitive: true, wholeWord: true)
+        );
+        expect($payload->content()['is_case_sensitive'])->toBeTrue()
+            ->and($payload->content()['is_whole_word'])->toBeTrue();
+    });
+});
+
+describe('LaraDumps::time() / stopTime()', function () {
+    it('time() sends a TimeTrackPayload with the reference', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->time('my-timer'));
+        expect($payload)->toBeInstanceOf(TimeTrackPayload::class)
+            ->and($payload->withLabel()->label)->toBe('my-timer');
+    });
+
+    it('stopTime() sends a TimeTrackPayload with stop=true', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->stopTime('my-timer'));
+        expect($payload)->toBeInstanceOf(TimeTrackPayload::class)
+            ->and($payload->content())->toHaveKey('end_time');
+    });
+});
+
+describe('LaraDumps::table()', function () {
+    it('sends a TablePayload', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->table([['name' => 'Luan']], 'Users'));
+        expect($payload->type())->toBe('table');
+    });
+});
+
+describe('LaraDumps::writeGrouped()', function () {
+    it('sends a GroupedDumpPayload', function () {
+        $tempFile = sys_get_temp_dir() . '/ld_wg_test.php';
+        file_put_contents($tempFile, "<?php\n\$x = 1;\n\$y = 2;\nds(\$x, \$y);\n");
+
+        $payload = capturePayload(fn () => (new LaraDumps())->writeGrouped([1, 2], $tempFile, 4));
+
+        @unlink($tempFile);
+
+        expect($payload)->toBeInstanceOf(GroupedDumpPayload::class)
+            ->and($payload->content()['items'])->toHaveCount(2);
+    });
+});
+
+describe('LaraDumps::send()', function () {
+    it('returns the payload', function () {
+        $ld      = new LaraDumps();
+        $payload = new ClearPayload();
+        LaraDumps::beforeSend(null);
+        $result = $ld->send($payload, withFrame: false);
+        expect($result)->toBeInstanceOf(ClearPayload::class);
+    });
+
+    it('sets notification id on the payload', function () {
+        $ld      = new LaraDumps();
+        $payload = new ClearPayload();
+        LaraDumps::beforeSend(null);
+        $ld->send($payload, withFrame: false);
+        expect($payload->toArray()['id'])->toBeString()->not->toBeEmpty();
+    });
+});
+
+describe('LaraDumps constructor sleep', function () {
+    it('does not sleep when config.sleep is 0 or missing', function () {
+        $start = microtime(true);
+        new LaraDumps();
+        $elapsed = microtime(true) - $start;
+        expect($elapsed)->toBeLessThan(1.0);
+    });
+});
+
+describe('LaraDumps::write() edge cases', function () {
+    it('returns self when write is called with null and payload is empty', function () {
+        $ld = new LaraDumps();
+        LaraDumps::beforeSend(null);
+
+        new ReflectionClass(LaraDumps::class);
+
+        $result = $ld->write(null);
+        expect($result)->toBeInstanceOf(LaraDumps::class);
+    });
+});
+
+describe('LaraDumps::phpinfo()', function () {
+    it('sends a PhpInfoPayload', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->phpinfo());
+        expect($payload)->toBeInstanceOf(PhpInfoPayload::class);
+    });
+});
+
+describe('LaraDumps::benchmark()', function () {
+    it('sends a BenchmarkPayload', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->benchmark(
+            fn () => usleep(1000),
+            fn () => usleep(2000),
+        ));
+        expect($payload)->toBeInstanceOf(BenchmarkPayload::class);
+    });
+});
+
+describe('LaraDumps::macosAutoLaunch()', function () {
+    it('returns early on non-Darwin systems or when config is false', function () {
+        LaraDumps::$beforeSend = null;
+        LaraDumps::macosAutoLaunch();
+
+        expect(true)->toBeTrue();
+    });
+});
+
+describe('Colors trait with color_in_screen config', function () {
+    it('danger() sends color red when color_in_screen is off', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->danger());
+        expect($payload)->toBeInstanceOf(ColorPayload::class)
+            ->and($payload->content()['color'])->toBe('red');
+    });
+
+    it('warning() sends color orange when color_in_screen is off', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->warning());
+        expect($payload)->toBeInstanceOf(ColorPayload::class)
+            ->and($payload->content()['color'])->toBe('orange');
+    });
+
+    it('success() sends color green when color_in_screen is off', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->success());
+        expect($payload)->toBeInstanceOf(ColorPayload::class)
+            ->and($payload->content()['color'])->toBe('green');
+    });
+
+    it('info() sends color blue when color_in_screen is off', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->info());
+        expect($payload)->toBeInstanceOf(ColorPayload::class)
+            ->and($payload->content()['color'])->toBe('blue');
+    });
+
+    it('black() is alias for dark()', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->black());
+        expect($payload)->toBeInstanceOf(ColorPayload::class)
+            ->and($payload->content()['color'])->toBe('black');
+    });
+});
+
+describe('Colors trait with color_in_screen enabled', function () {
+    beforeEach(function () {
+        $ref             = new ReflectionClass(Config::class);
+        $cache           = $ref->getProperty('cachedContent');
+        $this->origCache = $cache->getValue(null);
+
+        $cache->setValue(null, [
+            'observers' => ['enabled_in_testing' => true],
+            'config'    => ['color_in_screen' => true],
+        ]);
+    });
+
+    afterEach(function () {
+        $ref   = new ReflectionClass(Config::class);
+        $cache = $ref->getProperty('cachedContent');
+        $cache->setAccessible(true);
+        $cache->setValue(null, $this->origCache);
+    });
+
+    it('danger() sends to screen when color_in_screen is true', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->danger());
+        expect($payload)->toBeInstanceOf(ScreenPayload::class)
+            ->and($payload->toScreen()->screen_name)->toBe('danger');
+    });
+
+    it('warning() sends to screen when color_in_screen is true', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->warning());
+        expect($payload)->toBeInstanceOf(ScreenPayload::class)
+            ->and($payload->toScreen()->screen_name)->toBe('warning');
+    });
+
+    it('success() sends to screen when color_in_screen is true', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->success());
+        expect($payload)->toBeInstanceOf(ScreenPayload::class)
+            ->and($payload->toScreen()->screen_name)->toBe('success');
+    });
+
+    it('info() sends to screen when color_in_screen is true', function () {
+        $payload = capturePayload(fn () => (new LaraDumps())->info());
+        expect($payload)->toBeInstanceOf(ScreenPayload::class)
+            ->and($payload->toScreen()->screen_name)->toBe('info');
+    });
+});
+
+// ── macosAutoLaunch ───────────────────────────────────────────────────────────
+
+describe('LaraDumps::macosAutoLaunch() with config enabled', function () {
+    it('sets beforeSend closure when macos_auto_launch is enabled on Darwin', function () {
+        // Set the config
+        $ref       = new ReflectionClass(Config::class);
+        $cache     = $ref->getProperty('cachedContent');
+        $origCache = $cache->getValue(null);
+
+        $cache->setValue(null, [
+            'observers' => ['enabled_in_testing' => true],
+            'config'    => ['macos_auto_launch' => true],
+        ]);
+
+        LaraDumps::$beforeSend = null;
+        LaraDumps::macosAutoLaunch();
+
+        $cache->setValue(null, $origCache);
+
+        if (PHP_OS_FAMILY === 'Darwin') {
+            expect(LaraDumps::$beforeSend)->toBeInstanceOf(Closure::class);
+
+            $closure = LaraDumps::$beforeSend;
+            $closure();
+        } else {
+            expect(LaraDumps::$beforeSend)->toBeNull();
+        }
+
+        LaraDumps::$beforeSend = null;
+    });
+});
+
+describe('LaraDumps constructor with sleep config', function () {
+    it('sleeps when config.sleep is greater than 0', function () {
+        $ref       = new ReflectionClass(Config::class);
+        $cache     = $ref->getProperty('cachedContent');
+        $origCache = $cache->getValue(null);
+
+        $cache->setValue(null, [
+            'observers' => ['enabled_in_testing' => true],
+            'config'    => ['sleep' => 1],
+        ]);
+
+        $start = microtime(true);
+        new LaraDumps();
+        $elapsed = microtime(true) - $start;
+
+        $cache->setValue(null, $origCache);
+
+        expect($elapsed)->toBeGreaterThanOrEqual(0.9);
+    });
+});

--- a/tests/Feature/PayloadTest.php
+++ b/tests/Feature/PayloadTest.php
@@ -139,3 +139,48 @@ it('code snippet work properly - second Code Snippet file contents', function ()
         ->and($context[1])
         ->snippet->toHaveCount(15);
 });
+
+it('setCodeSnippet stores and includes code_snippet in toArray', function () {
+    $laradumps = new LaraDumps();
+    $payload   = new DumpPayload('test');
+    $payload->setFrame(['file' => 'Test.php', 'line' => 1]);
+
+    $snippet = [
+        ['file' => 'Test.php', 'line' => 10, 'snippet' => [9 => 'line 9', 10 => 'line 10', 11 => 'line 11']],
+    ];
+    $payload->setCodeSnippet($snippet);
+    $payload->setNotificationId('test-id');
+
+    $array = $payload->toArray();
+    expect($array['code_snippet'])->toBe($snippet);
+});
+
+it('getExtraPayload returns empty array when Laravel is not available', function () {
+    $payload = new DumpPayload('test');
+    $payload->setFrame(['file' => 'Test.php', 'line' => 1]);
+    $payload->setNotificationId('test-id');
+
+    $array = $payload->toArray();
+    // Without Laravel, extra should be empty array
+    expect($array['extra'])->toBe([]);
+});
+
+it('toArray includes original_content when set', function () {
+    $payload = new DumpPayload('test', 'original');
+    $payload->setFrame(['file' => 'Test.php', 'line' => 1]);
+    $payload->setNotificationId('test-id');
+
+    $array = $payload->toArray();
+    expect($array['dump'])->toHaveKey('original_content');
+});
+
+it('toArray does not add base original_content when originalContent property is null', function () {
+    // Use a ClearPayload which has no originalContent set
+    $payload = new \LaraDumps\LaraDumpsCore\Payloads\ClearPayload();
+    $payload->setFrame(['file' => 'Test.php', 'line' => 1]);
+    $payload->setNotificationId('test-id');
+
+    $array = $payload->toArray();
+    // ClearPayload content should not have 'original_content' key added by base Payload
+    expect($array['clear'])->not->toHaveKey('original_content');
+});

--- a/tests/Feature/Payloads/ClearPayloadTest.php
+++ b/tests/Feature/Payloads/ClearPayloadTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use LaraDumps\LaraDumpsCore\LaraDumps;
+use LaraDumps\LaraDumpsCore\Payloads\ClearPayload;
+use PHPUnit\Framework\TestCase;
+
+uses(TestCase::class);
+
+describe('ClearPayload', function () {
+    it('produces a toArray() with type clear so the app knows to wipe the screen', function () {
+        $payload = new ClearPayload();
+        $payload->setNotificationId('test-id');
+
+        expect($payload->toArray()['type'])->toBe('clear');
+    });
+
+    it('toArray() carries no extra data under the clear key', function () {
+        $payload = new ClearPayload();
+        $payload->setNotificationId('test-id');
+
+        expect($payload->toArray()['clear'])->toBe([]);
+    });
+
+    it('every send has a unique notification id', function () {
+        $captured = [];
+
+        LaraDumps::beforeSend(function ($p) use (&$captured) {
+            $captured[] = $p->toArray()['id'];
+        });
+
+        (new LaraDumps())->clear();
+        (new LaraDumps())->clear();
+
+        LaraDumps::beforeSend(null);
+
+        expect($captured[0])->not->toBe($captured[1]);
+    });
+});

--- a/tests/Feature/Payloads/ColorPayloadTest.php
+++ b/tests/Feature/Payloads/ColorPayloadTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use LaraDumps\LaraDumpsCore\Payloads\ColorPayload;
+use PHPUnit\Framework\TestCase;
+
+uses(TestCase::class);
+
+describe('ColorPayload', function () {
+    it('preserves the exact color string in content', function () {
+        expect((new ColorPayload('purple'))->content()['color'])->toBe('purple');
+    });
+
+    it('original_content is set to the color so the app can display what was passed', function () {
+        $payload = new ColorPayload('teal');
+        expect($payload->getOriginalContent())->toBe('teal');
+    });
+
+    it('defaults screen to home', function () {
+        expect((new ColorPayload('red'))->toScreen()->screen_name)->toBe('home');
+    });
+
+    it('respects a custom screen name', function () {
+        expect((new ColorPayload('red', screen: 'errors'))->toScreen()->screen_name)->toBe('errors');
+    });
+
+    it('defaults label to empty string', function () {
+        expect((new ColorPayload('red'))->withLabel()->label)->toBe('');
+    });
+
+    it('respects a custom label', function () {
+        expect((new ColorPayload('red', label: 'warning'))->withLabel()->label)->toBe('warning');
+    });
+});

--- a/tests/Feature/Payloads/JsonPayloadTest.php
+++ b/tests/Feature/Payloads/JsonPayloadTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use LaraDumps\LaraDumpsCore\Payloads\JsonPayload;
+use PHPUnit\Framework\TestCase;
+
+uses(TestCase::class);
+
+describe('JsonPayload', function () {
+    it('string and original_content are identical — the raw JSON is passed through unchanged', function () {
+        $json    = '{"user":{"id":1,"name":"Luan"},"roles":["admin"]}';
+        $content = (new JsonPayload($json))->content();
+
+        expect($content['string'])->toBe($json)
+            ->and($content['original_content'])->toBe($json);
+    });
+
+    it('does not re-encode or modify the JSON string', function () {
+        $json = '{"key":"value with \"quotes\" and \\\\backslash"}';
+        expect((new JsonPayload($json))->content()['string'])->toBe($json);
+    });
+
+    it('defaults screen to home', function () {
+        expect((new JsonPayload('{}'))->toScreen()->screen_name)->toBe('home');
+    });
+
+    it('respects a custom screen', function () {
+        expect((new JsonPayload('{}', screen: 'api'))->toScreen()->screen_name)->toBe('api');
+    });
+});

--- a/tests/Feature/Payloads/LabelPayloadTest.php
+++ b/tests/Feature/Payloads/LabelPayloadTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use LaraDumps\LaraDumpsCore\Payloads\LabelPayload;
+use PHPUnit\Framework\TestCase;
+
+uses(TestCase::class);
+
+describe('LabelPayload', function () {
+    it('withLabel carries the exact string passed to constructor', function () {
+        expect((new LabelPayload('My Label'))->withLabel()->label)->toBe('My Label');
+    });
+
+    it('original_content is set to the label string for serialization', function () {
+        $payload = new LabelPayload('Auth error');
+        expect($payload->getOriginalContent())->toBe('Auth error');
+    });
+
+    it('label with special characters is preserved exactly', function () {
+        $label = 'User: "João" — status=200';
+        expect((new LabelPayload($label))->withLabel()->label)->toBe($label);
+    });
+});

--- a/tests/Feature/Payloads/PhpInfoPayloadTest.php
+++ b/tests/Feature/Payloads/PhpInfoPayloadTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use LaraDumps\LaraDumpsCore\Payloads\PhpInfoPayload;
+use PHPUnit\Framework\TestCase;
+
+uses(TestCase::class);
+
+describe('PhpInfoPayload', function () {
+    it('every row has both property and value keys', function () {
+        $values = (new PhpInfoPayload())->content()['values'];
+
+        foreach ($values as $row) {
+            expect($row)->toHaveKeys(['property', 'value']);
+        }
+    });
+
+    it('reports the six expected PHP environment properties', function () {
+        $properties = array_column((new PhpInfoPayload())->content()['values'], 'property');
+
+        expect($properties)->toContain('PHP version')
+            ->and($properties)->toContain('Memory limit')
+            ->and($properties)->toContain('Max file upload size')
+            ->and($properties)->toContain('Max post size')
+            ->and($properties)->toContain('ini file')
+            ->and($properties)->toContain('Extensions');
+    });
+
+    it('PHP version matches the running process', function () {
+        $values  = (new PhpInfoPayload())->content()['values'];
+        $version = collect($values)->firstWhere('property', 'PHP version')['value'] ?? null;
+
+        expect($version)->toBe(phpversion());
+    });
+
+    it('header labels columns as Property and Value', function () {
+        expect((new PhpInfoPayload())->content()['header'])->toBe(['Property', 'Value']);
+    });
+
+    it('withLabel is always PHPINFO regardless of context', function () {
+        expect((new PhpInfoPayload())->withLabel()->label)->toBe('PHPINFO');
+    });
+});

--- a/tests/Feature/Payloads/ScreenPayloadTest.php
+++ b/tests/Feature/Payloads/ScreenPayloadTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use LaraDumps\LaraDumpsCore\Payloads\ScreenPayload;
+use PHPUnit\Framework\TestCase;
+
+uses(TestCase::class);
+
+describe('ScreenPayload', function () {
+    it('toScreen maps name directly to screen_name', function () {
+        $screen = (new ScreenPayload('errors'))->toScreen();
+        expect($screen->screen_name)->toBe('errors');
+    });
+
+    it('raiseIn defaults to 0 when not specified', function () {
+        expect((new ScreenPayload('logs'))->toScreen()->raise_in)->toBe(0);
+    });
+
+    it('newWindow defaults to false when not specified', function () {
+        expect((new ScreenPayload('logs'))->toScreen()->new_window)->toBeFalse();
+    });
+
+    it('raiseIn is forwarded to the Screen object', function () {
+        expect((new ScreenPayload('logs', raiseIn: 5))->toScreen()->raise_in)->toBe(5);
+    });
+
+    it('newWindow is forwarded to the Screen object', function () {
+        expect((new ScreenPayload('popup', newWindow: true))->toScreen()->new_window)->toBeTrue();
+    });
+
+    it('original_content captures the screen name for serialization', function () {
+        expect((new ScreenPayload('dashboard'))->getOriginalContent())->toBe('dashboard');
+    });
+});

--- a/tests/Feature/Payloads/TablePayloadTest.php
+++ b/tests/Feature/Payloads/TablePayloadTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use LaraDumps\LaraDumpsCore\Payloads\TablePayload;
+use PHPUnit\Framework\TestCase;
+
+uses(TestCase::class);
+
+describe('TablePayload', function () {
+    it('extracts column names from row keys', function () {
+        $content = (new TablePayload([['name' => 'Luan', 'age' => 35]]))->content();
+        expect($content['fields'])->toBe(['name', 'age']);
+    });
+
+    it('all rows are included in values', function () {
+        $data    = [['x' => 1], ['x' => 2], ['x' => 3]];
+        $content = (new TablePayload($data))->content();
+        expect($content['values'])->toHaveCount(3);
+    });
+
+    it('non-string values are JSON-encoded to prevent type loss', function () {
+        $content = (new TablePayload([['active' => true, 'score' => 9.5, 'tags' => ['a', 'b']]]))->content();
+        $row     = $content['values'][0];
+
+        expect($row['active'])->toBe('true')
+            ->and($row['score'])->toBe('9.5')
+            ->and($row['tags'])->toBe('["a","b"]');
+    });
+
+    it('string values are passed through without encoding', function () {
+        $content = (new TablePayload([['name' => 'Luan Freitas']]))->content();
+        expect($content['values'][0]['name'])->toBe('Luan Freitas');
+    });
+
+    it('object rows are cast to array before processing', function () {
+        $row     = (object) ['id' => 1, 'name' => 'test'];
+        $content = (new TablePayload([$row]))->content();
+        expect($content['fields'])->toBe(['id', 'name']);
+    });
+
+    it('name defaults to Table when omitted', function () {
+        expect((new TablePayload([]))->content()['label'])->toBe('Table');
+    });
+
+    it('custom name is propagated to label', function () {
+        expect((new TablePayload([], 'Orders'))->content()['label'])->toBe('Orders');
+    });
+
+    it('columns from later rows that are absent in earlier rows are also discovered', function () {
+        $data    = [['a' => 1], ['a' => 2, 'b' => 3]];
+        $content = (new TablePayload($data))->content();
+        expect($content['fields'])->toContain('a')->and($content['fields'])->toContain('b');
+    });
+});

--- a/tests/Feature/Payloads/TimeTrackPayloadTest.php
+++ b/tests/Feature/Payloads/TimeTrackPayloadTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use LaraDumps\LaraDumpsCore\Payloads\TimeTrackPayload;
+use PHPUnit\Framework\TestCase;
+
+uses(TestCase::class);
+
+describe('TimeTrackPayload', function () {
+    it('each instance generates a unique tracker_id', function () {
+        $a = (new TimeTrackPayload('ref'))->content()['tracker_id'];
+        $b = (new TimeTrackPayload('ref'))->content()['tracker_id'];
+
+        expect($a)->not->toBe($b);
+    });
+
+    it('time is a float representing the current unix timestamp', function () {
+        $before = microtime(true);
+        $time   = (new TimeTrackPayload('ref'))->content()['time'];
+        $after  = microtime(true);
+
+        expect($time)->toBeFloat()
+            ->and($time)->toBeGreaterThanOrEqual($before)
+            ->and($time)->toBeLessThanOrEqual($after);
+    });
+
+    it('end_time is absent when stop is false', function () {
+        expect((new TimeTrackPayload('ref', stop: false))->content())->not->toHaveKey('end_time');
+    });
+
+    it('end_time is present and a valid timestamp when stop is true', function () {
+        $before  = microtime(true);
+        $content = (new TimeTrackPayload('ref', stop: true))->content();
+        $after   = microtime(true);
+
+        expect($content)->toHaveKey('end_time')
+            ->and($content['end_time'])->toBeGreaterThanOrEqual($before)
+            ->and($content['end_time'])->toBeLessThanOrEqual($after);
+    });
+
+    it('withLabel uses the reference as the label so timers are identified by name', function () {
+        expect((new TimeTrackPayload('checkout-flow'))->withLabel()->label)->toBe('checkout-flow');
+    });
+});

--- a/tests/Feature/Payloads/ValidJsonPayloadTest.php
+++ b/tests/Feature/Payloads/ValidJsonPayloadTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use LaraDumps\LaraDumpsCore\LaraDumps;
+use LaraDumps\LaraDumpsCore\Payloads\ValidJsonPayload;
+use PHPUnit\Framework\TestCase;
+
+uses(TestCase::class);
+
+describe('ValidJsonPayload', function () {
+    it('produces a toArray() with type json_validate so the app triggers validation UI', function () {
+        $payload = new ValidJsonPayload();
+        $payload->setNotificationId('test-id');
+
+        expect($payload->toArray()['type'])->toBe('json_validate');
+    });
+
+    it('carries no content — it is a marker that tells the app to validate the previous dump', function () {
+        $payload = new ValidJsonPayload();
+        $payload->setNotificationId('test-id');
+
+        expect($payload->toArray()['json_validate'])->toBe([]);
+    });
+
+    it('isJson() sends this payload via LaraDumps', function () {
+        $captured = null;
+        LaraDumps::beforeSend(function ($p) use (&$captured) {
+            $captured = $p;
+        });
+        (new LaraDumps())->isJson();
+        LaraDumps::beforeSend(null);
+
+        expect($captured)->toBeInstanceOf(ValidJsonPayload::class);
+    });
+});

--- a/tests/Feature/Payloads/ValidateStringPayloadTest.php
+++ b/tests/Feature/Payloads/ValidateStringPayloadTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use LaraDumps\LaraDumpsCore\Payloads\ValidateStringPayload;
+use PHPUnit\Framework\TestCase;
+
+uses(TestCase::class);
+
+describe('ValidateStringPayload', function () {
+    it('content defaults to empty string when setContent is never called', function () {
+        expect((new ValidateStringPayload('contains'))->content()['content'])->toBe('');
+    });
+
+    it('setContent() updates the content key', function () {
+        $payload = (new ValidateStringPayload('contains'))->setContent('hello world');
+        expect($payload->content()['content'])->toBe('hello world');
+    });
+
+    it('defaults to case-insensitive and not whole-word', function () {
+        $content = (new ValidateStringPayload('contains'))->setContent('x')->content();
+        expect($content['is_case_sensitive'])->toBeFalse()
+            ->and($content['is_whole_word'])->toBeFalse();
+    });
+
+    it('setCaseSensitive(true) and setWholeWord(true) are independent flags', function () {
+        $payload = (new ValidateStringPayload('contains'))
+            ->setContent('foo')
+            ->setCaseSensitive(true);
+
+        expect($payload->content()['is_case_sensitive'])->toBeTrue()
+            ->and($payload->content()['is_whole_word'])->toBeFalse();
+    });
+
+    it('setCaseSensitive(false) explicitly reverts sensitivity after setting it', function () {
+        $payload = (new ValidateStringPayload('contains'))
+            ->setCaseSensitive(true)
+            ->setCaseSensitive(false);
+
+        expect($payload->content()['is_case_sensitive'])->toBeFalse();
+    });
+
+    it('setters return self for fluent chaining', function () {
+        $payload = new ValidateStringPayload('contains');
+        expect($payload->setContent('x'))->toBe($payload)
+            ->and($payload->setCaseSensitive())->toBe($payload)
+            ->and($payload->setWholeWord())->toBe($payload);
+    });
+
+    it('preserves the validate type string in content', function () {
+        expect((new ValidateStringPayload('not_contains'))->content()['type'])->toBe('not_contains');
+    });
+});


### PR DESCRIPTION
## Overview

This PR enhances the `ds()`, `dsd()`, and `dsq()` debugging functions with two major improvements:

1. **Variable name detection** — each dumped variable now shows its original name in the LaraDumps app
2. **Grouped dump mode** — multiple arguments are sent as a single grouped payload instead of individual dumps

---

## 1. Variable Name Detection

When calling `ds()` with multiple arguments, each variable's name is now automatically parsed from the source file and sent alongside the dump.

**Before (4.x)**

```php
$user = User::find(1);
$roles = $user->roles;

ds($user, $roles);
// App shows: two anonymous dumps with no labels
```

**After (ds-group)**

```php
$user = User::find(1);
$roles = $user->roles;

ds($user, $roles);
// App shows: dump labeled "user" and dump labeled "roles"
```

The line where each variable was **declared** (assigned with `=`) is also tracked and sent, so the app can point directly to the assignment rather than the `ds()` call.

---

## 2. Grouped Dump Mode

When `config.grouped_dumps` is enabled, multiple arguments passed to `ds()` are sent as a single `dump_group` payload instead of N individual payloads.

**Before (4.x)**

```php
ds($question, $conversationHistory, $pointsHistoryIds, $isFirstMessage);
// Sends 4 separate payloads — 4 entries in the app
```

**After (ds-group) — with `grouped_dumps: true`**

```php
ds($question, $conversationHistory, $pointsHistoryIds, $isFirstMessage);
// Sends 1 grouped payload — displayed as a single collapsible group in the app
// Each item shows: variable name, declaration line, type, and dump
```

Enable in `laradumps.yaml`:

```yaml
config:
    grouped_dumps: true
```

---

## 3. `Dumper::dump()` — `forceCloner` Flag

A new `forceCloner` parameter was added to always run the Symfony VarCloner pipeline, bypassing the early-return shortcuts for primitives. This is required for grouped dumps, which need the HTML dump representation for every type.

**Before (4.x)**

```php
// Strings, ints, bools returned as-is — no HTML wrapper
Dumper::dump('hello'); // → ['hello', $id]
Dumper::dump(42);      // → [42, $id]
```

**After (ds-group)**

```php
// forceCloner: true always produces the sf-dump HTML output
Dumper::dump('hello', forceCloner: true); // → ['<pre class=sf-dump...>', $id]
Dumper::dump(42, forceCloner: true);      // → ['<pre class=sf-dump...>', $id]
```

---

## 4. `DumpPayload` — `variable_name` Field

The `DumpPayload` now carries the variable name and sends it as `variable_name` in the payload content.

**Before (4.x)**

```php
// Payload content:
[
    'dump'             => $pre,
    'original_content' => ...,
    'variable_type'    => 'object',
]
```

**After (ds-group)**

```php
// Payload content:
[
    'dump'             => $pre,
    'original_content' => ...,
    'variable_type'    => 'object',
    'variable_name'    => 'user',   // ← new
]
```

---

## 5. `beforeWrite()` — Backward-Compatible Signature

The `variableName` is passed to `beforeWrite()` via a private `$pendingVariableName` property instead of a new method parameter. This keeps the method signature unchanged, so subclasses in `laradumps/laradumps` (and any other integrations) do not need to be updated.

**Before (4.x)**

```php
public function write(mixed $args = null, ?bool $autoInvokeApp = null): self
{
    [$payload, $id] = $this->beforeWrite($args)();
```

**After (ds-group)**

```php
public function write(mixed $args = null, ?bool $autoInvokeApp = null, ?string $variableName = null): self
{
    $this->pendingVariableName = $variableName; // set before, read inside beforeWrite()
    [$payload, $id] = $this->beforeWrite($args)();
```

---

## New Classes

| Class | Description |
|---|---|
| `Actions/VariableParser` | Parses PHP source via `token_get_all()` to extract variable names and declaration lines from a `ds()` call site |
| `Payloads/GroupedDumpPayload` | Payload type (`dump_group`) carrying an array of dump items for grouped display |

---

## Config

| Key | Default | Description |
|---|---|---|
| `config.grouped_dumps` | `false` | When `true`, multiple `ds()` args are sent as one grouped payload |
