### PR TITLE
feat: extract payload dispatching to a separate method

### DIFF
--- a/src/LaraDumps.php
+++ b/src/LaraDumps.php
@@ -99,9 +99,14 @@ class LaraDumps
             $closure($payload, $withFrame);
         }
 
-        (new Dispatcher())->handle($payload->toArray());
+        $this->dispatchPayload($payload);
 
         return $payload;
+    }
+
+    protected function dispatchPayload(Payload $payload): void
+    {
+        (new Dispatcher())->handle($payload->toArray());
     }
 
     public function writeGrouped(array $args, string $file, int $line): self


### PR DESCRIPTION
This pull request refactors how payloads are dispatched in the `LaraDumps` class to improve code organization and maintainability. The main change is extracting the payload dispatch logic into a new protected method.

**Code organization improvements:**

* Extracted the payload dispatch logic from the `send` method into a new protected method `dispatchPayload`, making the code more modular and easier to test or override. (`src/LaraDumps.php`)
* Updated the `send` method to call the new `dispatchPayload` method instead of directly instantiating and calling `Dispatcher`. (`src/LaraDumps.php`)